### PR TITLE
crypto/boring: Fix LDFLAGS

### DIFF
--- a/src/crypto/internal/boring/boring.go
+++ b/src/crypto/internal/boring/boring.go
@@ -8,8 +8,7 @@
 package boring
 
 /*
-// goboringcrypto_linux_amd64.syso references pthread functions.
-#cgo LDFLAGS: "-pthread"
+#cgo LDFLAGS: -ldl
 
 #include "goboringcrypto.h"
 */


### PR DESCRIPTION
LDFLAGS in our fork should container `-ldl` however upstream recently
added `-lpthread` because their boringcrypto .syso requires it now.

This got mangled in the rebase, this patch adds back the correct linker
argument.

Fixes #3 