### PR TITLE
.github/workflows: add workflow to build Docker image

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,9 @@
+FROM fedora:35
+
+MAINTAINER Daiki Ueno <dueno@redhat.com>
+
+RUN dnf -y update
+RUN dnf -y install 'dnf-command(builddep)'
+RUN dnf -y builddep golang
+RUN dnf -y install gcc-go
+RUN dnf clean all

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,39 @@
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: .ci/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This integrates a Docker image building into the GitHub actions, so the generated image can be used in our CI workflow for testing.

The workflow definition is based on:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

**Note that this workflow uses manual trigger (`workflow_dispatch`), which only works in the default branch on GitHub, so this PR is really intended for `main`.**

Signed-off-by: Daiki Ueno <dueno@redhat.com>