### PR TITLE
goopenssl.h: fix wrapper definitions to be compatible with OpenSSL headers

### DIFF
--- a/src/crypto/internal/boring/boring.go
+++ b/src/crypto/internal/boring/boring.go
@@ -151,31 +151,19 @@ func PanicIfStrictFIPS(msg string) {
 func NewOpenSSLError(msg string) error {
 	var e C.ulong
 	message := fmt.Sprintf("\n%v\nopenssl error(s):", msg)
-	if openSSLVersion() >= OPENSSL_VERSION_3_0_0 {
-		for {
-			var buf [256]C.char
-			var file, fnc, data *C.char
-			var line, flags C.int
-			e = C._goboringcrypto_internal_ERR_get_error_all(&file, &line, &fnc, &data, &flags)
-			if e == 0 {
-				break
-			}
+	for {
+		var buf [256]C.char
+		var file, fnc, data *C.char
+		var line, flags C.int
+		e = C._goboringcrypto_internal_ERR_get_error_all(&file, &line, &fnc, &data, &flags)
+		if e == 0 {
+			break
+		}
 
-			C._goboringcrypto_internal_ERR_error_string_n(e,(*C.uchar)(unsafe.Pointer (&buf[0])), 256)
-			message = fmt.Sprintf(
-				"%v\nfile: %v\nline: %v\nfunction: %v\nflags: %v\nerror string: %s\n",
-				message,C.GoString(file), line, C.GoString(fnc), flags, C.GoString(&(buf[0])))
-		}
-	} else {
-		for {
-			var buf [256]C.char
-			e = C._goboringcrypto_internal_ERR_get_error()
-			C._goboringcrypto_internal_ERR_error_string_n(e,(*C.uchar)(unsafe.Pointer (&buf[0])), 256)
-			if e == 0 {
-				break
-			}
-			message = fmt.Sprintf("%v: %v\n", message, buf)
-		}
+		C._goboringcrypto_internal_ERR_error_string_n(e, (*C.uchar)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+		message = fmt.Sprintf(
+			"%v\nfile: %v\nline: %v\nfunction: %v\nflags: %v\nerror string: %s\n",
+			message, C.GoString(file), line, C.GoString(fnc), flags, C.GoString(&(buf[0])))
 	}
 	return errors.New(message)
 }

--- a/src/crypto/internal/boring/ecdsa.go
+++ b/src/crypto/internal/boring/ecdsa.go
@@ -144,7 +144,7 @@ func SignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (r, s *big.Int
 func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) ([]byte, error) {
 	size := C._goboringcrypto_ECDSA_size(priv.key)
 	sig := make([]byte, size)
-	var sigLen C.uint
+	var sigLen C.size_t
 	if h == crypto.Hash(0) {
 		ok := C._goboringcrypto_internal_ECDSA_sign(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), &sigLen, priv.key) > 0
 		if !ok {

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -237,8 +237,6 @@ _goboringcrypto_EVP_md5_sha1(void) {
 
 typedef HMAC_CTX GO_HMAC_CTX;
 
-DEFINEFUNC(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))
-DEFINEFUNC(void, HMAC_CTX_cleanup, (GO_HMAC_CTX * arg0), (arg0))
 DEFINEFUNC(int, HMAC_Init_ex,
 		   (GO_HMAC_CTX * arg0, const void *arg1, int arg2, const GO_EVP_MD *arg3, ENGINE *arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
@@ -246,18 +244,18 @@ DEFINEFUNC(int, HMAC_Update, (GO_HMAC_CTX * arg0, const uint8_t *arg1, size_t ar
 DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX * arg0, uint8_t *arg1, unsigned int *arg2), (arg0, arg1, arg2))
 DEFINEFUNC(size_t, HMAC_CTX_copy, (GO_HMAC_CTX *dest, GO_HMAC_CTX *src), (dest, src))
 
-DEFINEFUNCINTERNAL(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNCINTERNAL(void, HMAC_CTX_cleanup, (GO_HMAC_CTX * arg0), (arg0))
 static inline void
 _goboringcrypto_HMAC_CTX_free(HMAC_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
    if (ctx != NULL) {
        _goboringcrypto_HMAC_CTX_cleanup(ctx);
        free(ctx);
    }
-#else
-	_goboringcrypto_internal_HMAC_CTX_free(ctx);
-#endif
 }
+#else
+DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
+#endif
 
 DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
 DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
@@ -276,29 +274,27 @@ _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 #endif
 }
 
-DEFINEFUNCINTERNAL(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))
 static inline GO_HMAC_CTX*
 _goboringcrypto_HMAC_CTX_new(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	GO_HMAC_CTX* ctx = malloc(sizeof(GO_HMAC_CTX));
 	if (ctx != NULL)
-		_goboringcrypto_HMAC_CTX_init(ctx);
+		_goboringcrypto_internal_HMAC_CTX_init(ctx);
 	return ctx;
-#else
-	return _goboringcrypto_internal_HMAC_CTX_new();
-#endif
 }
+#else
+DEFINEFUNC(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
+#endif
 
-DEFINEFUNCINTERNAL(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline void
 _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX* ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	_goboringcrypto_HMAC_CTX_cleanup(ctx);
 	_goboringcrypto_HMAC_CTX_init(ctx);
 #else
-	_goboringcrypto_internal_HMAC_CTX_reset(ctx);
+DEFINEFUNC(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
 #endif
-}
 
 int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest, const GO_HMAC_CTX *src);
 

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -153,7 +153,7 @@ static inline int _goboringcrypto_FIPS_mode(void) {
 #include <openssl/rand.h>
 
 DEFINEFUNC(int, RAND_set_rand_method, (const RAND_METHOD *rand), (rand))
-DEFINEFUNC(RAND_METHOD*, RAND_get_rand_method, (void), ())
+DEFINEFUNC(const RAND_METHOD*, RAND_get_rand_method, (void), ())
 DEFINEFUNC(int, RAND_bytes, (uint8_t * arg0, size_t arg1), (arg0, arg1))
 
 int _goboringcrypto_stub_openssl_rand(void);
@@ -277,7 +277,7 @@ _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 	return _goboringcrypto_internal_EVP_MD_size(arg0->md);
 }
 #else
-DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
+DEFINEFUNCINTERNAL(const EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
 # if OPENSSL_VERSION_NUMBER < 0x30000000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -89,10 +89,24 @@ _goboringcrypto_OPENSSL_setup(void) {
 
 #include <openssl/err.h>
 DEFINEFUNCINTERNAL(void, ERR_print_errors_fp, (FILE* fp), (fp))
-DEFINEFUNCINTERNAL(unsigned long, ERR_get_error, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+DEFINEFUNCINTERNAL(unsigned long, ERR_get_error_line_data,
+		   (const char **file, int *line, const char **data, int *flags),
+		   (file, line, data, flags))
+static inline unsigned long
+_goboringcrypto_internal_ERR_get_error_all(const char **file, int *line, const char **func, const char **data, int *flags)
+{
+	unsigned long e = _goboringcrypto_internal_ERR_get_error_line_data(file, line, data, flags);
+	if (e == 0 && func != NULL) {
+		*func = "unknown";
+	}
+	return e;
+}
+#else
 DEFINEFUNCINTERNAL(unsigned long, ERR_get_error_all,
 		(const char **file, int *line, const char **func, const char **data, int *flags),
 		(file, line, func, data, flags))
+#endif
 DEFINEFUNCINTERNAL(void, ERR_error_string_n, (unsigned long e, unsigned char *buf, size_t len), (e, buf, len))
 
 #include <openssl/crypto.h>

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -257,22 +257,30 @@ _goboringcrypto_HMAC_CTX_free(HMAC_CTX *ctx) {
 DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
 #endif
 
-DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
-DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 static inline size_t
 _goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	return _goboringcrypto_internal_EVP_MD_size(arg0->md);
-#elif OPENSSL_VERSION_NUMBER >= 0x30000000L
-	const EVP_MD* md;
-	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
-	return _goboringcrypto_internal_EVP_MD_get_size(md);
+}
 #else
+DEFINEFUNCINTERNAL(EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
+# if OPENSSL_VERSION_NUMBER < 0x30000000L
+static inline size_t
+_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
 	const EVP_MD* md;
 	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
 	return _goboringcrypto_internal_EVP_MD_size(md);
-#endif
 }
+# else
+DEFINEFUNCINTERNAL(size_t, EVP_MD_get_size, (const GO_EVP_MD *arg0), (arg0))
+static inline size_t
+_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
+	const EVP_MD* md;
+	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
+	return _goboringcrypto_internal_EVP_MD_get_size(md);
+}
+# endif
+#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -76,7 +76,7 @@ _goboringcrypto_DLOPEN_OPENSSL(void)
 #include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 
-DEFINEFUNCINTERNAL(int, OPENSSL_init, (void), ())
+DEFINEFUNCINTERNAL(void, OPENSSL_init, (void), ())
 
 static unsigned long _goboringcrypto_internal_OPENSSL_VERSION_NUMBER(void) {
 	return OPENSSL_VERSION_NUMBER;

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -296,12 +296,14 @@ DEFINEFUNC(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-static inline void
+static inline int
 _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX* ctx) {
 	_goboringcrypto_HMAC_CTX_cleanup(ctx);
 	_goboringcrypto_HMAC_CTX_init(ctx);
+	return 0;
+}
 #else
-DEFINEFUNC(void, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
+DEFINEFUNC(int, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
 #endif
 
 int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest, const GO_HMAC_CTX *src);
@@ -409,16 +411,14 @@ DEFINEFUNCINTERNAL(int, ECDSA_verify,
 	(int type, const unsigned char *dgst, size_t dgstlen, const unsigned char *sig, unsigned int siglen, EC_KEY *eckey),
 	(type, dgst, dgstlen, sig, siglen, eckey))
 
-DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_new, (void), ())
-DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_create, (void), ())
-
-static inline EVP_MD_CTX* _goboringcrypto_EVP_MD_CTX_create(void) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_EVP_MD_CTX_create();
+DEFINEFUNC(EVP_MD_CTX*, EVP_MD_CTX_create, (void), ())
 #else
+DEFINEFUNCINTERNAL(EVP_MD_CTX*, EVP_MD_CTX_new, (void), ())
+static inline EVP_MD_CTX* _goboringcrypto_EVP_MD_CTX_create(void) {
 	return _goboringcrypto_internal_EVP_MD_CTX_new();
-#endif
 }
+#endif
 
 DEFINEFUNCINTERNAL(int, EVP_PKEY_assign,
 	(EVP_PKEY *pkey, int type, void *eckey),
@@ -455,15 +455,14 @@ DEFINEFUNC(int, EVP_DigestVerifyFinal,
 int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, EVP_PKEY *eckey);
 int _goboringcrypto_EVP_verify(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, const uint8_t *sig, unsigned int slen, EVP_PKEY *key);
 
-DEFINEFUNCINTERNAL(void, EVP_MD_CTX_free, (EVP_MD_CTX *ctx), (ctx))
-DEFINEFUNCINTERNAL(void, EVP_MD_CTX_destroy, (EVP_MD_CTX *ctx), (ctx))
-static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_EVP_MD_CTX_destroy(ctx);
+DEFINEFUNC(void, EVP_MD_CTX_destroy, (EVP_MD_CTX *ctx), (ctx))
 #else
+DEFINEFUNCINTERNAL(void, EVP_MD_CTX_free, (EVP_MD_CTX *ctx), (ctx))
+static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 	return _goboringcrypto_internal_EVP_MD_CTX_free(ctx);
-#endif
 }
+#endif
 
 int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, unsigned int *arg4, GO_EC_KEY *arg5);
 int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, const uint8_t *arg3, unsigned int arg4, GO_EC_KEY *arg5);

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -97,35 +97,32 @@ DEFINEFUNCINTERNAL(void, ERR_error_string_n, (unsigned long e, unsigned char *bu
 
 #include <openssl/crypto.h>
 
-DEFINEFUNCINTERNAL(int, CRYPTO_num_locks, (void), ())
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(int, CRYPTO_num_locks, (void), ())
+#else
 static inline int
 _goboringcrypto_CRYPTO_num_locks(void) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	return _goboringcrypto_internal_CRYPTO_num_locks();
-#else
-	return CRYPTO_num_locks();
-#endif
+	return CRYPTO_num_locks(); /* defined as macro */
 }
-DEFINEFUNCINTERNAL(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function))
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(void, CRYPTO_set_id_callback, (unsigned long (*id_function)(void)), (id_function))
+#else
 static inline void
 _goboringcrypto_CRYPTO_set_id_callback(unsigned long (*id_function)(void)) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	_goboringcrypto_internal_CRYPTO_set_id_callback(id_function);
-#else
-	CRYPTO_set_id_callback(id_function);
-#endif
+	CRYPTO_set_id_callback(id_function); /* defined as macro */
 }
-DEFINEFUNCINTERNAL(void, CRYPTO_set_locking_callback,
+#endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+DEFINEFUNC(void, CRYPTO_set_locking_callback,
 	(void (*locking_function)(int mode, int n, const char *file, int line)), 
 	(locking_function))
+#else
 static inline void
 _goboringcrypto_CRYPTO_set_locking_callback(void (*locking_function)(int mode, int n, const char *file, int line)) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	_goboringcrypto_internal_CRYPTO_set_locking_callback(locking_function);
-#else
-	CRYPTO_set_locking_callback(locking_function);
-#endif
+	CRYPTO_set_locking_callback(locking_function); /* defined as macro */
 }
+#endif
 
 int _goboringcrypto_OPENSSL_thread_setup(void);
 

--- a/src/crypto/internal/boring/goopenssl.h
+++ b/src/crypto/internal/boring/goopenssl.h
@@ -418,7 +418,7 @@ DEFINEFUNC(int, ECDSA_do_verify, (const uint8_t *arg0, size_t arg1, const GO_ECD
 DEFINEFUNC(size_t, ECDSA_size, (const GO_EC_KEY *arg0), (arg0))
 
 DEFINEFUNCINTERNAL(int, ECDSA_sign, 
-	(int type, const unsigned char *dgst, size_t dgstlen, unsigned char *sig, unsigned int *siglen, EC_KEY *eckey),
+	(int type, const unsigned char *dgst, size_t dgstlen, unsigned char *sig, size_t *siglen, EC_KEY *eckey),
 	(type, dgst, dgstlen, sig, siglen, eckey))
 
 DEFINEFUNCINTERNAL(int, ECDSA_verify, 
@@ -456,7 +456,7 @@ DEFINEFUNC(int, EVP_DigestUpdate,
 	(EVP_MD_CTX* ctx, const void *d, size_t cnt),
 	(ctx, d, cnt))
 DEFINEFUNC(int, EVP_DigestSignFinal,
-	(EVP_MD_CTX* ctx, unsigned char *sig, unsigned int *siglen),
+	(EVP_MD_CTX* ctx, unsigned char *sig, size_t *siglen),
 	(ctx, sig, siglen))
 
 DEFINEFUNC(int, EVP_DigestVerifyInit,
@@ -466,7 +466,7 @@ DEFINEFUNC(int, EVP_DigestVerifyFinal,
 	(EVP_MD_CTX* ctx, const uint8_t *sig, unsigned int siglen),
 	(ctx, sig, siglen))
 
-int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, EVP_PKEY *eckey);
+int _goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, size_t *slen, EVP_PKEY *eckey);
 int _goboringcrypto_EVP_verify(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, const uint8_t *sig, unsigned int slen, EVP_PKEY *key);
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -478,7 +478,7 @@ static inline void _goboringcrypto_EVP_MD_CTX_free(EVP_MD_CTX *ctx) {
 }
 #endif
 
-int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, unsigned int *arg4, GO_EC_KEY *arg5);
+int _goboringcrypto_ECDSA_sign(EVP_MD *md, const uint8_t *arg1, size_t arg2, uint8_t *arg3, size_t *arg4, GO_EC_KEY *arg5);
 int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, const uint8_t *arg3, unsigned int arg4, GO_EC_KEY *arg5);
 
 #include <openssl/rsa.h>
@@ -487,7 +487,7 @@ int _goboringcrypto_ECDSA_verify(EVP_MD *md, const uint8_t *arg1, size_t arg2, c
 typedef RSA GO_RSA;
 typedef BN_GENCB GO_BN_GENCB;
 
-int _goboringcrypto_EVP_RSA_sign(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, unsigned int *slen, RSA *rsa);
+int _goboringcrypto_EVP_RSA_sign(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, size_t *slen, RSA *rsa);
 int _goboringcrypto_EVP_RSA_verify(EVP_MD* md, const uint8_t *msg, unsigned int msgLen, const uint8_t *sig, unsigned int slen, GO_RSA *rsa);
 
 DEFINEFUNC(GO_RSA *, RSA_new, (void), ())
@@ -499,7 +499,7 @@ DEFINEFUNC(int, RSA_public_decrypt,
 	(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding),
 	(flen, from, to, rsa, padding))
 DEFINEFUNC(int, RSA_sign,
-	(int arg0, const uint8_t *arg1, unsigned int arg2, uint8_t *arg3, unsigned int *arg4, GO_RSA *arg5),
+	(int arg0, const uint8_t *arg1, unsigned int arg2, uint8_t *arg3, size_t *arg4, GO_RSA *arg5),
 	(arg0, arg1, arg2, arg3, arg4, arg5))
 DEFINEFUNC(int, RSA_verify,
 	(int arg0, const uint8_t *arg1, unsigned int arg2, const uint8_t *arg3, unsigned int arg4, GO_RSA *arg5),
@@ -788,10 +788,10 @@ _goboringcrypto_EVP_PKEY_CTX_set_rsa_mgf1_md(GO_EVP_PKEY_CTX * ctx, const GO_EVP
 }
 
 DEFINEFUNC(int, EVP_PKEY_decrypt,
-		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4),
+		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, unsigned int arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
 DEFINEFUNC(int, EVP_PKEY_encrypt,
-		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, unsigned int *arg2, const uint8_t *arg3, unsigned int arg4),
+		   (GO_EVP_PKEY_CTX * arg0, uint8_t *arg1, size_t *arg2, const uint8_t *arg3, unsigned int arg4),
 		   (arg0, arg1, arg2, arg3, arg4))
 DEFINEFUNC(int, EVP_PKEY_decrypt_init, (GO_EVP_PKEY_CTX * arg0), (arg0))
 DEFINEFUNC(int, EVP_PKEY_encrypt_init, (GO_EVP_PKEY_CTX * arg0), (arg0))

--- a/src/crypto/internal/boring/openssl_ecdsa_signature.c
+++ b/src/crypto/internal/boring/openssl_ecdsa_signature.c
@@ -7,7 +7,7 @@
 #include "goboringcrypto.h"
 
 int
-_goboringcrypto_ECDSA_sign(EVP_MD* md, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, GO_EC_KEY *eckey)
+_goboringcrypto_ECDSA_sign(EVP_MD* md, const uint8_t *msg, size_t msgLen, uint8_t *sig, size_t *slen, GO_EC_KEY *eckey)
 {
     int result;
     EVP_PKEY *key = _goboringcrypto_EVP_PKEY_new();

--- a/src/crypto/internal/boring/openssl_evp.c
+++ b/src/crypto/internal/boring/openssl_evp.c
@@ -7,7 +7,7 @@
 #include "goboringcrypto.h"
 
 int
-_goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, unsigned int *slen, EVP_PKEY *key) {
+_goboringcrypto_EVP_sign(EVP_MD* md, EVP_PKEY_CTX *ctx, const uint8_t *msg, size_t msgLen, uint8_t *sig, size_t *slen, EVP_PKEY *key) {
     EVP_MD_CTX *mdctx = NULL;
     int ret = 0;
 

--- a/src/crypto/internal/boring/openssl_port_rsa.c
+++ b/src/crypto/internal/boring/openssl_port_rsa.c
@@ -19,7 +19,7 @@ int _goboringcrypto_RSA_generate_key_fips(GO_RSA *rsa, int size, GO_BN_GENCB *cb
 	return ret;
 }
 
-int _goboringcrypto_RSA_digest_and_sign_pss_mgf1(GO_RSA *rsa, unsigned int *out_len, uint8_t *out, size_t max_out,
+int _goboringcrypto_RSA_digest_and_sign_pss_mgf1(GO_RSA *rsa, size_t *out_len, uint8_t *out, size_t max_out,
 		const uint8_t *in, size_t in_len, EVP_MD *md, const EVP_MD *mgf1_md, int salt_len)
 {
 	EVP_PKEY_CTX *ctx;
@@ -173,7 +173,7 @@ err:
 	return ret;
 }
 
-int _goboringcrypto_EVP_RSA_sign(EVP_MD *md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, unsigned int *slen, RSA *rsa)
+int _goboringcrypto_EVP_RSA_sign(EVP_MD *md, const uint8_t *msg, unsigned int msgLen, uint8_t *sig, size_t *slen, RSA *rsa)
 {
 	int result;
 	EVP_PKEY *key = _goboringcrypto_EVP_PKEY_new();

--- a/src/crypto/internal/boring/rsa.go
+++ b/src/crypto/internal/boring/rsa.go
@@ -200,7 +200,7 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 	init func(*C.GO_EVP_PKEY_CTX) C.int,
-	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.uint, *C.uint8_t, C.uint) C.int,
+	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.size_t, *C.uint8_t, C.uint) C.int,
 	in []byte) ([]byte, error) {
 
 	pkey, ctx, err := setupRSA(withKey, padding, h, label, saltLen, ch, init)
@@ -210,7 +210,7 @@ func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 	defer C._goboringcrypto_EVP_PKEY_free(pkey)
 	defer C._goboringcrypto_EVP_PKEY_CTX_free(ctx)
 
-	var outLen C.uint
+	var outLen C.size_t
 	if crypt(ctx, nil, &outLen, base(in), C.uint(len(in))) == 0 {
 		return nil, NewOpenSSLError("EVP_PKEY_decrypt/encrypt failed")
 	}
@@ -251,7 +251,7 @@ func decryptInit(ctx *C.GO_EVP_PKEY_CTX) C.int {
 	return C._goboringcrypto_EVP_PKEY_decrypt_init(ctx)
 }
 
-func decrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+func decrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uint8_t, inLen C.uint) C.int {
 	return C._goboringcrypto_EVP_PKEY_decrypt(ctx, out, outLen, in, inLen)
 }
 
@@ -259,7 +259,7 @@ func encryptInit(ctx *C.GO_EVP_PKEY_CTX) C.int {
 	return C._goboringcrypto_EVP_PKEY_encrypt_init(ctx)
 }
 
-func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.uint, in *C.uint8_t, inLen C.uint) C.int {
+func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uint8_t, inLen C.uint) C.int {
 	return C._goboringcrypto_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
 }
 
@@ -308,7 +308,7 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte, msgIsHashed
 	}
 
 	var out []byte
-	var outLen C.uint
+	var outLen C.size_t
 
 	if msgIsHashed {
 		PanicIfStrictFIPS("You must provide a raw unhashed message for PKCS1v15 signing and use HashSignPKCS1v15 instead of SignPKCS1v15")


### PR DESCRIPTION
I was [told](https://gitlab.com/gnutls/gnutls/-/merge_requests/1544#note_853664582) that modern compilers support `typeof` keyword (`__typeof__` when used in headers), which could be useful to detect any mismatches in `dlopen`'ed function prototypes and the actual declarations in headers. After applying this [change](https://github.com/ueno/go/commit/b85fb8abe0298b556a209f10de99eeb0a1239682) to `goopenssl.h`, it reported a few errors, which this PR tries to fix.