### PR TITLE
crypto/boring: fix use-after-free bug in VerifyECDSA

### DIFF
--- a/src/crypto/internal/boring/ecdsa.go
+++ b/src/crypto/internal/boring/ecdsa.go
@@ -173,6 +173,7 @@ func VerifyECDSA(pub *PublicKeyECDSA, msg []byte, r, s *big.Int, h crypto.Hash) 
 	}
 	if h == crypto.Hash(0) {
 		ok := C._goboringcrypto_internal_ECDSA_verify(0, base(msg), C.size_t(len(msg)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
+		runtime.KeepAlive(pub)
 		return ok
 	}
 	md := cryptoHashToMD(h)


### PR DESCRIPTION
Because of the PublicKeyECDSA (pub) finalizer, any time pub.key is passed to cgo, that call must be followed by a call to runtime.KeepAlive, to make sure pub is not collected (and finalized) before the call returns.

VerifyECDSA does call runtime.KeepAlive, but that call will be deleted if the compiler can prove that h is always 0, leaving _goboringcrypto_internal_ECDSA_verify call vulnerable at garbage collector mercy.

The fix is easy, just add a runtime.KeepAlice call to the h == crypto.Hash(0) branch.

PD. We (Go team at Microsoft) found this bug when porting the OpenSSL bindings in here to our own repo, located at https://github.com/microsoft/go-crypto-openssl. To be specific, the test that caught the use-after-free error was [TestECDSASignAndVerify](https://github.com/microsoft/go-crypto-openssl/blob/b91d5c94e49eab418792fa842d40028570ce4a09/openssl/ecdsa_test.go#L48), in case you want to port it to your test-suite.

Ported from https://pagure.io/go/pull-request/4#