### PR TITLE
crypto/boring: Remove restriction on build architecture

### DIFF
--- a/src/crypto/internal/boring/aes.go
+++ b/src/crypto/internal/boring/aes.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/boring.go
+++ b/src/crypto/internal/boring/boring.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/ecdsa.go
+++ b/src/crypto/internal/boring/ecdsa.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/hmac.go
+++ b/src/crypto/internal/boring/hmac.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/notboring.go
+++ b/src/crypto/internal/boring/notboring.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !linux || !amd64 || !cgo || android || cmd_go_bootstrap || msan || no_openssl
-// +build !linux !amd64 !cgo android cmd_go_bootstrap msan no_openssl
+//go:build !linux || !cgo || android || cmd_go_bootstrap || msan || no_openssl
+// +build !linux !cgo android cmd_go_bootstrap msan no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/rand.go
+++ b/src/crypto/internal/boring/rand.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/rsa.go
+++ b/src/crypto/internal/boring/rsa.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 

--- a/src/crypto/internal/boring/sha.go
+++ b/src/crypto/internal/boring/sha.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && amd64 && !android && !cmd_go_bootstrap && !msan && !no_openssl
-// +build linux,amd64,!android,!cmd_go_bootstrap,!msan,!no_openssl
+//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
+// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
 
 package boring
 


### PR DESCRIPTION
The previous ports had this change, though it was apparently missed in the 1.18 rebase.

Signed-off-by: Daiki Ueno <dueno@redhat.com>