### PR TITLE
.github/workflows/build-image.yml: pull in openssl-devel

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -2,8 +2,8 @@ FROM fedora:35
 
 MAINTAINER Daiki Ueno <dueno@redhat.com>
 
-RUN dnf -y update
-RUN dnf -y install 'dnf-command(builddep)'
-RUN dnf -y builddep golang
-RUN dnf -y install gcc-go
-RUN dnf clean all
+RUN dnf -y update && \
+    dnf -y install 'dnf-command(builddep)' && \
+    dnf -y builddep golang && \
+    dnf -y install gcc-go openssl-devel && \
+    dnf clean all


### PR DESCRIPTION
The openssl-devel package needs to be manually installed, as it is not
part of the golang build dependencies in Fedora.

Signed-off-by: Daiki Ueno <dueno@redhat.com>