### PR TITLE
Fix initial patch setup script

### DIFF
--- a/scripts/setup-initial-patch.sh
+++ b/scripts/setup-initial-patch.sh
@@ -48,6 +48,17 @@ sed -i -e "s/boring.VerifyECDSA(b, hash, r, s)/boring.VerifyECDSA(b, hash, r, s,
 sed -i -e "s/boring\.Enabled/boring\.Enabled()/g" ${GO_SOURCES}
 sed -i -e "s/\"crypto\/internal\/boring\"/boring \"crypto\/internal\/backend\"/g" ${GO_SOURCES}
 sed -i -e "s/const boringEnabled/var boringEnabled/g" ${GO_SOURCES}
+sed -i -e "s/testConfig.Clone()/testConfigTemplate()/g" src/crypto/tls/boring_test.go
+cat << EOF > src/crypto/tls/boring_test.go
+func testConfigTemplate() *Config {
+	config := testConfig.Clone()
+	if boring.Enabled() {
+		config.Certificates[0].Certificate = [][]byte{testRSA2048Certificate}
+		config.Certificates[0].PrivateKey = testRSA2048PrivateKey
+	}
+	return config
+}
+EOF
 
 # Remove the crypto/internal/boring code as we're replacing it with the openssl backend code.
 rm src/crypto/internal/boring/*.*

--- a/scripts/setup-initial-patch.sh
+++ b/scripts/setup-initial-patch.sh
@@ -48,7 +48,7 @@ sed -i -e "s/boring.VerifyECDSA(b, hash, r, s)/boring.VerifyECDSA(b, hash, r, s,
 sed -i -e "s/boring\.Enabled/boring\.Enabled()/g" ${GO_SOURCES}
 sed -i -e "s/\"crypto\/internal\/boring\"/boring \"crypto\/internal\/backend\"/g" ${GO_SOURCES}
 sed -i -e "s/const boringEnabled/var boringEnabled/g" ${GO_SOURCES}
-sed -i -e "s/testConfig.Clone()/testConfigTemplate()/g" src/crypto/tls/boring_test.go
+sed -i -e "s/testConfig\.Clone()/testConfigTemplate()/g" src/crypto/tls/boring_test.go
 cat << EOF > src/crypto/tls/boring_test.go
 func testConfigTemplate() *Config {
 	config := testConfig.Clone()


### PR DESCRIPTION
Adds some more changes which cause the TLS boring tests to pass.
After this change, running the script, applying the patches and
then running `GOLANG_FIPS=1 go test -run Boring ./...` all tests
will pass.