### PR TITLE
Fix initial setup script (pt 2)

### DIFF
--- a/scripts/setup-initial-patch.sh
+++ b/scripts/setup-initial-patch.sh
@@ -49,7 +49,7 @@ sed -i -e "s/boring\.Enabled/boring\.Enabled()/g" ${GO_SOURCES}
 sed -i -e "s/\"crypto\/internal\/boring\"/boring \"crypto\/internal\/backend\"/g" ${GO_SOURCES}
 sed -i -e "s/const boringEnabled/var boringEnabled/g" ${GO_SOURCES}
 sed -i -e "s/testConfig\.Clone()/testConfigTemplate()/g" src/crypto/tls/boring_test.go
-cat << EOF > src/crypto/tls/boring_test.go
+cat << EOF >> src/crypto/tls/boring_test.go
 func testConfigTemplate() *Config {
 	config := testConfig.Clone()
 	if boring.Enabled() {


### PR DESCRIPTION
Not sure how this got by my testing, but when
the testConfigTemplate function is added to the
Go source file we should use a bash append (">>")
instead of the alternative which will replace the
entire contents of the file with only the function,
causing compilation to fail.