### PR TITLE
crypto/tls: delegate ECDH operation to openssl-fips package

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -16,6 +16,384 @@ index a0a41a50de..208aa7008a 100644
  
  -- issue16333/issue16333.go --
  package vendoring17
+diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
+index 5b82dc287d..eaaa5e8d6d 100644
+--- a/src/cmd/link/internal/ld/lib.go
++++ b/src/cmd/link/internal/ld/lib.go
+@@ -1015,7 +1015,7 @@ var hostobj []Hostobj
+ // These packages can use internal linking mode.
+ // Others trigger external mode.
+ var internalpkg = []string{
+-	"crypto/internal/boring",
++	"vendor/github.com/golang-fips/openssl-fips/openssl",
+ 	"crypto/x509",
+ 	"net",
+ 	"os/user",
+diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
+new file mode 100644
+index 0000000000..2ecbf30c51
+--- /dev/null
++++ b/src/crypto/internal/backend/nobackend.go
+@@ -0,0 +1,128 @@
++// Copyright 2017 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build !linux || !cgo || android || cmd_go_bootstrap || msan || gocrypt
++// +build !linux !cgo android cmd_go_bootstrap msan gocrypt
++
++package backend
++
++import (
++	"crypto"
++	"crypto/cipher"
++	"crypto/internal/boring/sig"
++	"hash"
++	"math/big"
++)
++
++func Enabled() bool { return false }
++
++// Unreachable marks code that should be unreachable
++// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.
++func Unreachable() {
++	// Code that's unreachable when using OpenSSLCrypto
++	// is exactly the code we want to detect for reporting
++	// standard Go crypto.
++	sig.StandardCrypto()
++}
++
++// UnreachableExceptTests marks code that should be unreachable
++// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.
++func UnreachableExceptTests() {}
++
++type randReader int
++
++func (randReader) Read(b []byte) (int, error) { panic("opensslcrypto: not available") }
++
++const RandReader = randReader(0)
++
++func NewSHA1() hash.Hash   { panic("opensslcrypto: not available") }
++func NewSHA224() hash.Hash { panic("opensslcrypto: not available") }
++func NewSHA256() hash.Hash { panic("opensslcrypto: not available") }
++func NewSHA384() hash.Hash { panic("opensslcrypto: not available") }
++func NewSHA512() hash.Hash { panic("opensslcrypto: not available") }
++
++func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("opensslcrypto: not available") }
++
++func NewAESCipher(key []byte) (cipher.Block, error) { panic("opensslcrypto: not available") }
++
++type PublicKeyECDSA struct{ _ int }
++type PrivateKeyECDSA struct{ _ int }
++
++func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
++	panic("opensslcrypto: not available")
++}
++func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*PrivateKeyECDSA, error) {
++	panic("opensslcrypto: not available")
++}
++func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
++	panic("opensslcrypto: not available")
++}
++func SignECDSA(priv *PrivateKeyECDSA, hash []byte) (r, s *big.Int, err error) {
++	panic("opensslcrypto: not available")
++}
++func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
++	panic("opensslcrypto: not available")
++}
++
++type PublicKeyECDH struct{ _ int }
++type PrivateKeyECDH struct{ _ int }
++
++func GenerateKeyECDH(curve string) (X, Y, D *big.Int, err error) {
++	panic("opensslcrypto: not available")
++}
++func NewPrivateKeyECDH(curve string, X, Y, D *big.Int) (*PrivateKeyECDSA, error) {
++	panic("opensslcrypto: not available")
++}
++func NewPublicKeyECDH(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
++	panic("opensslcrypto: not available")
++}
++func SharedKeyECDH(priv *PrivateKeyECDSA, peerPublicKey []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++
++type PublicKeyRSA struct{ _ int }
++type PrivateKeyRSA struct{ _ int }
++
++func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
++	panic("opensslcrypto: not available")
++}
++func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, error) {
++	panic("opensslcrypto: not available")
++}
++func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
++	panic("opensslcrypto: not available")
++}
++func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
++	panic("opensslcrypto: not available")
++}
++func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
++	panic("opensslcrypto: not available")
++}
++func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
++	panic("opensslcrypto: not available")
++}
+diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
+new file mode 100644
+index 0000000000..c357b73cdd
+--- /dev/null
++++ b/src/crypto/internal/backend/openssl.go
+@@ -0,0 +1,94 @@
++// Copyright 2017 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++//go:build linux && !android && !gocrypt && !cmd_go_bootstrap && !msan
++// +build linux,!android,!gocrypt,!cmd_go_bootstrap,!msan
++
++// Package openssl provides access to OpenSSLCrypto implementation functions.
++// Check the variable Enabled to find out whether OpenSSLCrypto is available.
++// If OpenSSLCrypto is not available, the functions in this package all panic.
++package backend
++
++import (
++	"github.com/golang-fips/openssl-fips/openssl"
++)
++
++// Enabled controls whether FIPS crypto is enabled.
++var Enabled = openssl.Enabled
++
++// Unreachable marks code that should be unreachable
++// when OpenSSLCrypto is in use. It panics only when
++// the system is in FIPS mode.
++func Unreachable() {
++	if Enabled() {
++		panic("opensslcrypto: invalid code execution")
++	}
++}
++
++// Provided by runtime.crypto_backend_runtime_arg0 to avoid os import.
++func runtime_arg0() string
++
++func hasSuffix(s, t string) bool {
++	return len(s) > len(t) && s[len(s)-len(t):] == t
++}
++
++// UnreachableExceptTests marks code that should be unreachable
++// when OpenSSLCrypto is in use. It panics.
++func UnreachableExceptTests() {
++	name := runtime_arg0()
++	// If OpenSSLCrypto ran on Windows we'd need to allow _test.exe and .test.exe as well.
++	if Enabled() && !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
++		println("opensslcrypto: unexpected code execution in", name)
++		panic("opensslcrypto: invalid code execution")
++	}
++}
++
++var ExecutingTest = openssl.ExecutingTest
++
++const RandReader = openssl.RandReader
++
++var NewSHA1 = openssl.NewSHA1
++var NewSHA224 = openssl.NewSHA224
++var NewSHA256 = openssl.NewSHA256
++var NewSHA384 = openssl.NewSHA384
++var NewSHA512 = openssl.NewSHA512
++
++var NewHMAC = openssl.NewHMAC
++
++var NewAESCipher = openssl.NewAESCipher
++
++type PublicKeyECDSA = openssl.PublicKeyECDSA
++type PrivateKeyECDSA = openssl.PrivateKeyECDSA
++
++var GenerateKeyECDSA = openssl.GenerateKeyECDSA
++var NewPrivateKeyECDSA = openssl.NewPrivateKeyECDSA
++var NewPublicKeyECDSA = openssl.NewPublicKeyECDSA
++var SignECDSA = openssl.SignECDSA
++var SignMarshalECDSA = openssl.SignMarshalECDSA
++var VerifyECDSA = openssl.VerifyECDSA
++
++type PublicKeyECDH = openssl.PublicKeyECDH
++type PrivateKeyECDH = openssl.PrivateKeyECDH
++
++var GenerateKeyECDH = openssl.GenerateKeyECDH
++var NewPrivateKeyECDH = openssl.NewPrivateKeyECDH
++var NewPublicKeyECDH = openssl.NewPublicKeyECDH
++var SharedKeyECDH = openssl.SharedKeyECDH
++
++type PublicKeyRSA = openssl.PublicKeyRSA
++type PrivateKeyRSA = openssl.PrivateKeyRSA
++
++var DecryptRSAOAEP = openssl.DecryptRSAOAEP
++var DecryptRSAPKCS1 = openssl.DecryptRSAPKCS1
++var DecryptRSANoPadding = openssl.DecryptRSANoPadding
++var EncryptRSAOAEP = openssl.EncryptRSAOAEP
++var EncryptRSAPKCS1 = openssl.EncryptRSAPKCS1
++var EncryptRSANoPadding = openssl.EncryptRSANoPadding
++var GenerateKeyRSA = openssl.GenerateKeyRSA
++var NewPrivateKeyRSA = openssl.NewPrivateKeyRSA
++var NewPublicKeyRSA = openssl.NewPublicKeyRSA
++var SignRSAPKCS1v15 = openssl.SignRSAPKCS1v15
++var SignRSAPSS = openssl.SignRSAPSS
++var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
++var VerifyRSAPSS = openssl.VerifyRSAPSS
+diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
+index dabc67423d..c29fa125c3 100644
+--- a/src/crypto/tls/boring.go
++++ b/src/crypto/tls/boring.go
+@@ -12,6 +12,14 @@ import (
+ 	"crypto/x509"
+ )
+ 
++import boring "crypto/internal/backend"
++
++func init() {
++	if boring.Enabled && !boring.ExecutingTest() {
++		fipstls.Force()
++	}
++}
++
+ // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
+ func needFIPS() bool {
+ 	return fipstls.Required()
+@@ -91,7 +99,7 @@ func isBoringCertificate(c *x509.Certificate) bool {
+ 	default:
+ 		return false
+ 	case *rsa.PublicKey:
+-		if size := k.N.BitLen(); size != 2048 && size != 3072 {
++		if size := k.N.BitLen(); size < 2048 || (size%512) != 0 {
+ 			return false
+ 		}
+ 	case *ecdsa.PublicKey:
+diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
+index 8dd477a021..32ee250724 100644
+--- a/src/crypto/tls/boring_test.go
++++ b/src/crypto/tls/boring_test.go
+@@ -22,6 +22,8 @@ import (
+ 	"time"
+ )
+ 
++import boring "crypto/internal/backend"
++
+ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test := func(name string, v uint16, msg string) {
+ 		t.Run(name, func(t *testing.T) {
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index 0950bb0ac4..9a76903b41 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
+ }
+ 
+ func TestAlertFlushing(t *testing.T) {
++	t.Skip("unsupported in FIPS mode, different error returned")
+ 	c, s := localPipe(t)
+ 	done := make(chan bool)
+ 
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index 314016979a..c4e732fb28 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -17,6 +17,8 @@ import (
+ 	"golang.org/x/crypto/hkdf"
+ )
+ 
++import boring "crypto/internal/backend"
++
+ // This file contains the functions necessary to compute the TLS 1.3 key
+ // schedule. See RFC 8446, Section 7.
+ 
+@@ -129,9 +131,18 @@ func generateECDHEParameters(rand io.Reader, curveID CurveID) (ecdheParameters,
+ 
+ 	p := &nistParameters{curveID: curveID}
+ 	var err error
+-	p.privateKey, p.x, p.y, err = elliptic.GenerateKey(curve, rand)
+-	if err != nil {
+-		return nil, err
++	if boring.Enabled {
++		var d *big.Int
++		p.x, p.y, d, err = boring.GenerateKeyECDH(curve.Params().Name)
++		if err != nil {
++			return nil, err
++		}
++		p.privateKey = d.Bytes()
++	} else {
++		p.privateKey, p.x, p.y, err = elliptic.GenerateKey(curve, rand)
++		if err != nil {
++			return nil, err
++		}
+ 	}
+ 	return p, nil
+ }
+@@ -165,16 +176,30 @@ func (p *nistParameters) PublicKey() []byte {
+ }
+ 
+ func (p *nistParameters) SharedKey(peerPublicKey []byte) []byte {
+-	curve, _ := curveForCurveID(p.curveID)
+-	// Unmarshal also checks whether the given point is on the curve.
+-	x, y := elliptic.Unmarshal(curve, peerPublicKey)
+-	if x == nil {
+-		return nil
+-	}
++	if boring.Enabled {
++		curve, _ := curveForCurveID(p.curveID)
++		k := new(big.Int).SetBytes(p.privateKey)
++		priv, err := boring.NewPrivateKeyECDH(curve.Params().Name, p.x, p.y, k)
++		if err != nil {
++			return nil
++		}
++		sharedKey, err := boring.SharedKeyECDH(priv, peerPublicKey)
++		if err != nil {
++			return nil
++		}
++		return sharedKey
++	} else {
++		curve, _ := curveForCurveID(p.curveID)
++		// Unmarshal also checks whether the given point is on the curve.
++		x, y := elliptic.Unmarshal(curve, peerPublicKey)
++		if x == nil {
++			return nil
++		}
+ 
+-	xShared, _ := curve.ScalarMult(x, y, p.privateKey)
+-	sharedKey := make([]byte, (curve.Params().BitSize+7)/8)
+-	return xShared.FillBytes(sharedKey)
++		xShared, _ := curve.ScalarMult(x, y, p.privateKey)
++		sharedKey := make([]byte, (curve.Params().BitSize+7)/8)
++		return xShared.FillBytes(sharedKey)
++	}
+ }
+ 
+ type x25519Parameters struct {
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index ed8ddcb307..f8d29618d9 100644
 --- a/src/go/build/deps_test.go
@@ -95,37 +473,6 @@ index ed8ddcb307..f8d29618d9 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index dabc67423d..4dfd431613 100644
---- a/src/crypto/tls/boring.go
-+++ b/src/crypto/tls/boring.go
-@@ -12,6 +12,14 @@ import (
- 	"crypto/x509"
- )
- 
-+import boring "crypto/internal/backend"
-+
-+func init() {
-+	if boring.Enabled && !boring.ExecutingTest() {
-+		fipstls.Force()
-+	}
-+}
-+
- // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
- func needFIPS() bool {
- 	return fipstls.Required()
-@@ -91,7 +99,7 @@ func isBoringCertificate(c *x509.Certificate) bool {
- 	default:
- 		return false
- 	case *rsa.PublicKey:
--		if size := k.N.BitLen(); size != 2048 && size != 3072 {
-+		if size := k.N.BitLen(); size < 2048 || (size%512) != 0 {
- 			return false
- 		}
- 	case *ecdsa.PublicKey:
-diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
-new file mode 100644
-index 0000000000..e69de29bb2
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253..dc25cdcfd5 100644
 --- a/src/runtime/runtime_boring.go
@@ -140,238 +487,3 @@ index 5a98b20253..dc25cdcfd5 100644
 +	return boring_runtime_arg0()
 +}
 \ No newline at end of file
-diff --git a/src/cmd/link/internal/ld/lib.go b/src/cmd/link/internal/ld/lib.go
-index 5b82dc287d..eaaa5e8d6d 100644
---- a/src/cmd/link/internal/ld/lib.go
-+++ b/src/cmd/link/internal/ld/lib.go
-@@ -1015,7 +1015,7 @@ var hostobj []Hostobj
- // These packages can use internal linking mode.
- // Others trigger external mode.
- var internalpkg = []string{
--	"crypto/internal/boring",
-+	"vendor/github.com/golang-fips/openssl-fips/openssl",
- 	"crypto/x509",
- 	"net",
- 	"os/user",
-diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
-new file mode 100644
-index 0000000000..6273b1ec6d
---- /dev/null
-+++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,112 @@
-+// Copyright 2017 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build !linux || !cgo || android || cmd_go_bootstrap || msan || gocrypt
-+// +build !linux !cgo android cmd_go_bootstrap msan gocrypt
-+
-+package backend
-+
-+import (
-+	"crypto"
-+	"crypto/cipher"
-+	"crypto/internal/boring/sig"
-+	"hash"
-+	"math/big"
-+)
-+
-+func Enabled() bool { return false }
-+
-+// Unreachable marks code that should be unreachable
-+// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.
-+func Unreachable() {
-+	// Code that's unreachable when using OpenSSLCrypto
-+	// is exactly the code we want to detect for reporting
-+	// standard Go crypto.
-+	sig.StandardCrypto()
-+}
-+
-+// UnreachableExceptTests marks code that should be unreachable
-+// when OpenSSLCrypto is in use. It is a no-op without OpenSSLCrypto.
-+func UnreachableExceptTests() {}
-+
-+type randReader int
-+
-+func (randReader) Read(b []byte) (int, error) { panic("opensslcrypto: not available") }
-+
-+const RandReader = randReader(0)
-+
-+func NewSHA1() hash.Hash   { panic("opensslcrypto: not available") }
-+func NewSHA224() hash.Hash { panic("opensslcrypto: not available") }
-+func NewSHA256() hash.Hash { panic("opensslcrypto: not available") }
-+func NewSHA384() hash.Hash { panic("opensslcrypto: not available") }
-+func NewSHA512() hash.Hash { panic("opensslcrypto: not available") }
-+
-+func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("opensslcrypto: not available") }
-+
-+func NewAESCipher(key []byte) (cipher.Block, error) { panic("opensslcrypto: not available") }
-+
-+type PublicKeyECDSA struct{ _ int }
-+type PrivateKeyECDSA struct{ _ int }
-+
-+func GenerateKeyECDSA(curve string) (X, Y, D *big.Int, err error) {
-+	panic("opensslcrypto: not available")
-+}
-+func NewPrivateKeyECDSA(curve string, X, Y, D *big.Int) (*PrivateKeyECDSA, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func NewPublicKeyECDSA(curve string, X, Y *big.Int) (*PublicKeyECDSA, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func SignECDSA(priv *PrivateKeyECDSA, hash []byte) (r, s *big.Int, err error) {
-+	panic("opensslcrypto: not available")
-+}
-+func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, r, s *big.Int) bool {
-+	panic("opensslcrypto: not available")
-+}
-+
-+type PublicKeyRSA struct{ _ int }
-+type PrivateKeyRSA struct{ _ int }
-+
-+func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv *big.Int, err error) {
-+	panic("opensslcrypto: not available")
-+}
-+func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv *big.Int) (*PrivateKeyRSA, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func NewPublicKeyRSA(N, E *big.Int) (*PublicKeyRSA, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
-+	panic("opensslcrypto: not available")
-+}
-+func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
-+	panic("opensslcrypto: not available")
-+}
-+func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
-+	panic("opensslcrypto: not available")
-+}
-diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
-new file mode 100644
-index 0000000000..c5360fb8dc
---- /dev/null
-+++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,86 @@
-+// Copyright 2017 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
-+
-+//go:build linux && !android && !gocrypt && !cmd_go_bootstrap && !msan
-+// +build linux,!android,!gocrypt,!cmd_go_bootstrap,!msan
-+
-+// Package openssl provides access to OpenSSLCrypto implementation functions.
-+// Check the variable Enabled to find out whether OpenSSLCrypto is available.
-+// If OpenSSLCrypto is not available, the functions in this package all panic.
-+package backend
-+
-+import (
-+	"github.com/golang-fips/openssl-fips/openssl"
-+)
-+
-+// Enabled controls whether FIPS crypto is enabled.
-+var Enabled = openssl.Enabled
-+
-+// Unreachable marks code that should be unreachable
-+// when OpenSSLCrypto is in use. It panics only when
-+// the system is in FIPS mode.
-+func Unreachable() {
-+	if Enabled() {
-+		panic("opensslcrypto: invalid code execution")
-+	}
-+}
-+
-+// Provided by runtime.crypto_backend_runtime_arg0 to avoid os import.
-+func runtime_arg0() string
-+
-+func hasSuffix(s, t string) bool {
-+	return len(s) > len(t) && s[len(s)-len(t):] == t
-+}
-+
-+// UnreachableExceptTests marks code that should be unreachable
-+// when OpenSSLCrypto is in use. It panics.
-+func UnreachableExceptTests() {
-+	name := runtime_arg0()
-+	// If OpenSSLCrypto ran on Windows we'd need to allow _test.exe and .test.exe as well.
-+	if Enabled() && !hasSuffix(name, "_test") && !hasSuffix(name, ".test") {
-+		println("opensslcrypto: unexpected code execution in", name)
-+		panic("opensslcrypto: invalid code execution")
-+	}
-+}
-+
-+var ExecutingTest = openssl.ExecutingTest
-+
-+const RandReader = openssl.RandReader
-+
-+var NewSHA1 = openssl.NewSHA1
-+var NewSHA224 = openssl.NewSHA224
-+var NewSHA256 = openssl.NewSHA256
-+var NewSHA384 = openssl.NewSHA384
-+var NewSHA512 = openssl.NewSHA512
-+
-+var NewHMAC = openssl.NewHMAC
-+
-+var NewAESCipher = openssl.NewAESCipher
-+
-+type PublicKeyECDSA = openssl.PublicKeyECDSA
-+type PrivateKeyECDSA = openssl.PrivateKeyECDSA
-+
-+var GenerateKeyECDSA = openssl.GenerateKeyECDSA
-+var NewPrivateKeyECDSA = openssl.NewPrivateKeyECDSA
-+var NewPublicKeyECDSA = openssl.NewPublicKeyECDSA
-+var SignECDSA = openssl.SignECDSA
-+var SignMarshalECDSA = openssl.SignMarshalECDSA
-+var VerifyECDSA = openssl.VerifyECDSA
-+
-+type PublicKeyRSA = openssl.PublicKeyRSA
-+type PrivateKeyRSA = openssl.PrivateKeyRSA
-+
-+var DecryptRSAOAEP = openssl.DecryptRSAOAEP
-+var DecryptRSAPKCS1 = openssl.DecryptRSAPKCS1
-+var DecryptRSANoPadding = openssl.DecryptRSANoPadding
-+var EncryptRSAOAEP = openssl.EncryptRSAOAEP
-+var EncryptRSAPKCS1 = openssl.EncryptRSAPKCS1
-+var EncryptRSANoPadding = openssl.EncryptRSANoPadding
-+var GenerateKeyRSA = openssl.GenerateKeyRSA
-+var NewPrivateKeyRSA = openssl.NewPrivateKeyRSA
-+var NewPublicKeyRSA = openssl.NewPublicKeyRSA
-+var SignRSAPKCS1v15 = openssl.SignRSAPKCS1v15
-+var SignRSAPSS = openssl.SignRSAPSS
-+var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
-+var VerifyRSAPSS = openssl.VerifyRSAPSS
-diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
-index b6eb488a4d..3fb1fa5110 100644
---- a/src/crypto/tls/handshake_client_test.go
-+++ b/src/crypto/tls/handshake_client_test.go
-@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
- }
- 
- func TestAlertFlushing(t *testing.T) {
-+	t.Skip("unsupported in FIPS mode, different error returned")
- 	c, s := localPipe(t)
- 	done := make(chan bool)
-

--- a/scripts/create-secondary-patch.sh
+++ b/scripts/create-secondary-patch.sh
@@ -32,7 +32,7 @@ rm src/crypto/internal/boring/*.*
 rm src/crypto/boring/boring_test.go
 
 # Add new openssl backend to module and vendor it.
-echo "require github.com/golang-fips/openssl-fips v0.0.0-20220505153334-362f46022010" >> src/go.mod
+echo "require github.com/golang-fips/openssl-fips v0.0.0-20220823170308-c70d375e6e8b" >> src/go.mod
 cd src
 go mod tidy
 go mod vendor


### PR DESCRIPTION
This is an attempt to use the ECDH functions provided by https://github.com/golang-fips/openssl-fips/pull/8 in crypto/tls.

Fixes: #33