### PR TITLE
Update initial setup patch with new modifications

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -276,7 +276,7 @@ new file mode 100644
 index 0000000000..c5360fb8dc
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,86 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -106,7 +106,7 @@ index dabc67423d..4dfd431613 100644
 +import boring "crypto/internal/backend"
 +
 +func init() {
-+	if boring.Enabled {
++	if boring.Enabled && !boring.ExecutingTest() {
 +		fipstls.Force()
 +	}
 +}
@@ -323,6 +323,8 @@ index 0000000000..c5360fb8dc
 +	}
 +}
 +
++var ExecutingTest = openssl.ExecutingTest
++
 +const RandReader = openssl.RandReader
 +
 +var NewSHA1 = openssl.NewSHA1
@@ -361,3 +363,15 @@ index 0000000000..c5360fb8dc
 +var SignRSAPSS = openssl.SignRSAPSS
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index b6eb488a4d..3fb1fa5110 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
+ }
+ 
+ func TestAlertFlushing(t *testing.T) {
++	t.Skip("unsupported in FIPS mode, different error returned")
+ 	c, s := localPipe(t)
+ 	done := make(chan bool)
+


### PR DESCRIPTION
A few new changes included in the initial setup patch combined with https://github.com/golang-fips/openssl-fips/pull/10 allow new branches setup with the setup script to execute the tests without any further modification.