### PR TITLE
Add testing farm integration

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,73 @@
+name: "Test Go"
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ack:
+    name: "Check if the comment is valid"
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request
+      && contains(github.event.comment.body, '/test')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)    
+    outputs:
+      architectures: ${{ steps.set-compose.outputs.architectures }}
+      composes: ${{ steps.set-compose.outputs.composes }}
+    steps:
+      - name: "Set the targets"
+        id: set-compose
+        shell: python
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          import os
+          import re
+          import argparse
+
+          composes=['RHEL-7-LatestReleased', 'RHEL-8-Released', 'RHEL-9.0.0-Nightly']
+          architectures=['x86_64', 'ppc64le', 's390x', 'aarch64']
+
+          parser = argparse.ArgumentParser(prog="ack")
+
+          parser.add_argument('--os', choices=composes, nargs='+', default=composes)
+          parser.add_argument('--arch', choices=architectures, nargs='+', default=architectures)
+
+
+          try:
+              comment = re.search('/test (.*)', os.environ['COMMENT']).group(1)
+          except:
+              comment = ""
+
+
+          options = parser.parse_intermixed_args(comment.split())
+
+          print("::set-output name=architectures::{}".format(options.arch))
+          print("::set-output name=composes::{}".format(options.os))
+
+  test:
+    name: "Schedule tests"
+    runs-on: ubuntu-latest
+    needs: ack
+    strategy:
+      matrix:
+        arch: ${{fromJson(needs.ack.outputs.architectures)}}
+        compose: ${{fromJson(needs.ack.outputs.composes)}}
+    steps:
+      - name: Checkout repo and switch to corresponding pull request
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
+      - name: Schedule test on Testing Farm
+        uses: sclorg/testing-farm-as-github-action@v1
+        with:
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: https://github.com/alexsaezm/go-fips-plans.git
+          git_ref: main
+          compose: ${{ matrix.compose }}
+          arch: ${{ matrix.arch }}
+          tf_scope: private
+          pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
+          create_issue_comment: false

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -26,20 +26,32 @@ jobs:
           import re
           import argparse
 
-          composes=['RHEL-7-LatestReleased', 'RHEL-8-Released', 'RHEL-9.0.0-Nightly']
+          class ParseCompose(argparse.Action):
+              def __call__(self, parser, namespace, values, option_string=None):
+                  setattr(namespace, self.dest, list())
+                  for v in values:
+                      getattr(namespace, self.dest).append(composes[v])
+                      
+
+          composes = {
+              'rhel7': 'RHEL-7-LatestReleased',
+              'rhel8': 'RHEL-8-Released',
+              'rhel9': 'RHEL-9.0.0-Nightly'
+          }
+
+          #composes=['RHEL-7-LatestReleased', 'RHEL-8-Released', 'RHEL-9.0.0-Nightly']
           architectures=['x86_64', 'ppc64le', 's390x', 'aarch64']
 
           parser = argparse.ArgumentParser(prog="ack")
 
-          parser.add_argument('--os', choices=composes, nargs='+', default=composes)
-          parser.add_argument('--arch', choices=architectures, nargs='+', default=architectures)
+          parser.add_argument('-o', '--os', choices=composes, nargs='+', action=ParseCompose, default=list(composes.values()))
+          parser.add_argument('-a', '--arch', choices=architectures, nargs='+', default=architectures)
 
 
           try:
               comment = re.search('/test (.*)', os.environ['COMMENT']).group(1)
           except:
               comment = ""
-
 
           options = parser.parse_intermixed_args(comment.split())
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -78,3 +78,6 @@ jobs:
           pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
           update_pull_request_status: true
           create_issue_comment: false
+        env:
+          REPO_URL: "https://github.com/alexsaezm/go-fips.git"
+          PR_NUM: "${{ github.event.issue.number }}"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,6 +3,8 @@ name: "Test Go"
 on:
   issue_comment:
     types: [created]
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions: read-all
 
 jobs:
   ack:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -66,6 +66,11 @@ jobs:
         arch: ${{fromJson(needs.ack.outputs.architectures)}}
         compose: ${{fromJson(needs.ack.outputs.composes)}}
     steps:
+      - name: Checkout repo and switch to corresponding pull request
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
       - name: Schedule test on Testing Farm
         uses: sclorg/testing-farm-as-github-action@v1
         with:
@@ -78,6 +83,3 @@ jobs:
           pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
           update_pull_request_status: true
           create_issue_comment: false
-        env:
-          REPO_URL: "https://github.com/alexsaezm/go-fips.git"
-          PR_NUM: "${{ github.event.issue.number }}"

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -66,11 +66,6 @@ jobs:
         arch: ${{fromJson(needs.ack.outputs.architectures)}}
         compose: ${{fromJson(needs.ack.outputs.composes)}}
     steps:
-      - name: Checkout repo and switch to corresponding pull request
-        uses: actions/checkout@v3
-        with:
-          ref: "refs/pull/${{ github.event.issue.number }}/head"
-
       - name: Schedule test on Testing Farm
         uses: sclorg/testing-farm-as-github-action@v1
         with:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -39,7 +39,6 @@ jobs:
               'rhel9': 'RHEL-9.0.0-Nightly'
           }
 
-          #composes=['RHEL-7-LatestReleased', 'RHEL-8-Released', 'RHEL-9.0.0-Nightly']
           architectures=['x86_64', 'ppc64le', 's390x', 'aarch64']
 
           parser = argparse.ArgumentParser(prog="ack")

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -70,7 +70,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v1
         with:
           api_key: ${{ secrets.TF_API_KEY }}
-          git_url: https://github.com/alexsaezm/go-fips-plans.git
+          git_url: https://github.com/golang-fips/release.git
           git_ref: main
           compose: ${{ matrix.compose }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -66,11 +66,6 @@ jobs:
         arch: ${{fromJson(needs.ack.outputs.architectures)}}
         compose: ${{fromJson(needs.ack.outputs.composes)}}
     steps:
-      - name: Checkout repo and switch to corresponding pull request
-        uses: actions/checkout@v3
-        with:
-          ref: "refs/pull/${{ github.event.issue.number }}/head"
-
       - name: Schedule test on Testing Farm
         uses: sclorg/testing-farm-as-github-action@v1
         with:
@@ -79,6 +74,7 @@ jobs:
           git_ref: main
           compose: ${{ matrix.compose }}
           arch: ${{ matrix.arch }}
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.comment.issue_url }}"
           tf_scope: private
           pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
           update_pull_request_status: true

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -34,7 +34,7 @@ jobs:
                       
 
           composes = {
-              'rhel7': 'RHEL-7-LatestReleased',
+              'rhel7': 'RHEL-7-LatestUpdated',
               'rhel8': 'RHEL-8-Released',
               'rhel9': 'RHEL-9.0.0-Nightly'
           }

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -74,7 +74,7 @@ jobs:
           git_ref: main
           compose: ${{ matrix.compose }}
           arch: ${{ matrix.arch }}
-          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.comment.issue_url }}"
+          variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }}"
           tf_scope: private
           pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
           update_pull_request_status: true

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -82,4 +82,5 @@ jobs:
           arch: ${{ matrix.arch }}
           tf_scope: private
           pull_request_status_name: "${{ matrix.compose }} - ${{ matrix.arch }}"
+          update_pull_request_status: true
           create_issue_comment: false


### PR DESCRIPTION
This PR adds the command /test to the PR comments. This schedules jobs in Testing Farm.
It is also suppose to be running in read only mode as I followed [this documentation page](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).

P.S: It used to be this pr #19 but due a mistake, I closed it.