### PR TITLE
Update initial patch to support TLS 1.3

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -1,75 +1,3 @@
-diff --git a/src/crypto/ed25519/ed25519vectors_test.go b/src/crypto/ed25519/ed25519vectors_test.go
-index f933f2800a..223ce04340 100644
---- a/src/crypto/ed25519/ed25519vectors_test.go
-+++ b/src/crypto/ed25519/ed25519vectors_test.go
-@@ -72,6 +72,7 @@ func TestEd25519Vectors(t *testing.T) {
- }
-
- func downloadEd25519Vectors(t *testing.T) []byte {
-+	t.Skip("skipping test that downloads external data")
- 	testenv.MustHaveExternalNetwork(t)
-
- 	// Create a temp dir and modcache subdir.
-diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
-index 84fcf62..e442bcc 100644
---- a/src/crypto/ed25519/ed25519_test.go
-+++ b/src/crypto/ed25519/ed25519_test.go
-@@ -187,6 +187,7 @@ func TestMalleability(t *testing.T) {
- }
-
- func TestAllocations(t *testing.T) {
-+	t.Skip("Allocations test broken with openssl linkage")
- 	if boring.Enabled {
- 		t.Skip("skipping allocations test with BoringCrypto")
- 	}
-diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 141fdb9fbd..ae8002703c 100644
---- a/src/go/build/deps_test.go
-+++ b/src/go/build/deps_test.go
-@@ -414,19 +414,23 @@ var depsRules = `
- 	< crypto/internal/edwards25519
- 	< crypto/cipher;
- 
--	crypto/cipher,
-+	fmt, crypto/cipher,
- 	crypto/internal/boring/bcache
- 	< crypto/internal/boring
-+	< github.com/golang-fips/openssl-fips/openssl
-+	< crypto/internal/backend
- 	< crypto/boring
- 	< crypto/aes, crypto/des, crypto/hmac, crypto/md5, crypto/rc4,
- 	  crypto/sha1, crypto/sha256, crypto/sha512
- 	< CRYPTO;
- 
--	CGO, fmt, net !< CRYPTO;
-+	CGO, net !< CRYPTO;
- 
- 	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
- 	CRYPTO, FMT, math/big, embed
-+	< github.com/golang-fips/openssl-fips/openssl/bbig
- 	< crypto/internal/boring/bbig
-+	< crypto/internal/backend/bbig
- 	< crypto/internal/randutil
- 	< crypto/rand
- 	< crypto/ed25519
-@@ -644,7 +648,7 @@ var buildIgnore = []byte("\n//go:build ignore")
- 
- func findImports(pkg string) ([]string, error) {
- 	vpkg := pkg
--	if strings.HasPrefix(pkg, "golang.org") {
-+	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
- 		vpkg = "vendor/" + pkg
- 	}
- 	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -654,7 +658,7 @@ func findImports(pkg string) ([]string, error) {
- 	}
- 	var imports []string
- 	var haveImport = map[string]bool{}
--	if pkg == "crypto/internal/boring" {
-+	if pkg == "crypto/internal/boring" || pkg == "github.com/golang-fips/openssl-fips/openssl" {
- 		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
- 	}
- 	fset := token.NewFileSet()
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 index a0a41a50de..208aa7008a 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
@@ -88,29 +16,83 @@ index a0a41a50de..208aa7008a 100644
  
  -- issue16333/issue16333.go --
  package vendoring17
+diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
+index 7c5181788f..102c4e5355 100644
+--- a/src/crypto/ed25519/ed25519_test.go
++++ b/src/crypto/ed25519/ed25519_test.go
+@@ -187,6 +187,7 @@ func TestMalleability(t *testing.T) {
+ }
+ 
+ func TestAllocations(t *testing.T) {
++	t.Skip("Allocations test broken with openssl linkage")
+ 	if boring.Enabled {
+ 		t.Skip("skipping allocations test with BoringCrypto")
+ 	}
+diff --git a/src/crypto/ed25519/ed25519vectors_test.go b/src/crypto/ed25519/ed25519vectors_test.go
+index f933f2800a..223ce04340 100644
+--- a/src/crypto/ed25519/ed25519vectors_test.go
++++ b/src/crypto/ed25519/ed25519vectors_test.go
+@@ -72,6 +72,7 @@ func TestEd25519Vectors(t *testing.T) {
+ }
+ 
+ func downloadEd25519Vectors(t *testing.T) []byte {
++	t.Skip("skipping test that downloads external data")
+ 	testenv.MustHaveExternalNetwork(t)
+ 
+ 	// Create a temp dir and modcache subdir.
+diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
+new file mode 100644
+index 0000000000..c0800df578
+--- /dev/null
++++ b/src/crypto/internal/backend/bbig/big.go
+@@ -0,0 +1,38 @@
++// Copyright 2022 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// This is a mirror of crypto/internal/boring/bbig/big.go.
++
++package bbig
++
++import (
++	"math/big"
++	"unsafe"
++
++	"github.com/golang-fips/openssl-fips/openssl"
++)
++
++func Enc(b *big.Int) openssl.BigInt {
++	if b == nil {
++		return nil
++	}
++	x := b.Bits()
++	if len(x) == 0 {
++		return openssl.BigInt{}
++	}
++	// TODO: Use unsafe.Slice((*uint)(&x[0]), len(x)) once go1.16 is no longer supported.
++	return (*(*[]uint)(unsafe.Pointer(&x)))[:len(x)]
++}
++
++func Dec(b openssl.BigInt) *big.Int {
++	if b == nil {
++		return nil
++	}
++	if len(b) == 0 {
++		return new(big.Int)
++	}
++	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
++	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
++	return new(big.Int).SetBits(x)
++}
 diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
 new file mode 100644
 index 0000000000..e69de29bb2
-diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
-index 5a98b20253..dc25cdcfd5 100644
---- a/src/runtime/runtime_boring.go
-+++ b/src/runtime/runtime_boring.go
-@@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
- 
- //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
- func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
-+
-+//go:linkname crypto_backend_runtime_arg0 crypto/internal/backend.runtime_arg0
-+func crypto_backend_runtime_arg0() string {
-+	return boring_runtime_arg0()
-+}
-\ No newline at end of file
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..e5a9823141
+index 0000000000..98066f55fc
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,148 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -126,6 +108,7 @@ index 0000000000..e5a9823141
 +	"crypto/internal/boring/sig"
 +	"github.com/golang-fips/openssl-fips/openssl"
 +	"hash"
++	"io"
 +)
 +
 +var enabled = false
@@ -251,12 +234,19 @@ index 0000000000..e5a9823141
 +func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
 +	panic("boringcrypto: not available")
 +}
++
++func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
++	panic("boringcrypto: not available")
++}
++func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
++	panic("boringcrypto: not available")
++}
 diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
 new file mode 100644
-index 0000000000..c5360fb8dc
+index 0000000000..ec562b535d
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,103 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -333,6 +323,14 @@ index 0000000000..c5360fb8dc
 +var SignMarshalECDSA = openssl.SignMarshalECDSA
 +var VerifyECDSA = openssl.VerifyECDSA
 +
++type PublicKeyECDH = openssl.PublicKeyECDH
++type PrivateKeyECDH = openssl.PrivateKeyECDH
++
++var GenerateKeyECDH = openssl.GenerateKeyECDH
++var NewPrivateKeyECDH = openssl.NewPrivateKeyECDH
++var NewPublicKeyECDH = openssl.NewPublicKeyECDH
++var SharedKeyECDH = openssl.SharedKeyECDH
++
 +type PublicKeyRSA = openssl.PublicKeyRSA
 +type PrivateKeyRSA = openssl.PrivateKeyRSA
 +
@@ -349,71 +347,20 @@ index 0000000000..c5360fb8dc
 +var SignRSAPSS = openssl.SignRSAPSS
 +var VerifyRSAPKCS1v15 = openssl.VerifyRSAPKCS1v15
 +var VerifyRSAPSS = openssl.VerifyRSAPSS
-diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
-index b6eb488a4d..3fb1fa5110 100644
---- a/src/crypto/tls/handshake_client_test.go
-+++ b/src/crypto/tls/handshake_client_test.go
-@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
- }
- 
- func TestAlertFlushing(t *testing.T) {
-+       t.Skip("unsupported in FIPS mode, different error returned")
- 	c, s := localPipe(t)
- 	done := make(chan bool)
-
-diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
-new file mode 100644
-index 0000000000..c0800df578
---- /dev/null
-+++ b/src/crypto/internal/backend/bbig/big.go
-@@ -0,0 +1,38 @@
-+// Copyright 2022 The Go Authors. All rights reserved.
-+// Use of this source code is governed by a BSD-style
-+// license that can be found in the LICENSE file.
 +
-+// This is a mirror of crypto/internal/boring/bbig/big.go.
-+
-+package bbig
-+
-+import (
-+	"math/big"
-+	"unsafe"
-+
-+	"github.com/golang-fips/openssl-fips/openssl"
-+)
-+
-+func Enc(b *big.Int) openssl.BigInt {
-+	if b == nil {
-+		return nil
-+	}
-+	x := b.Bits()
-+	if len(x) == 0 {
-+		return openssl.BigInt{}
-+	}
-+	// TODO: Use unsafe.Slice((*uint)(&x[0]), len(x)) once go1.16 is no longer supported.
-+	return (*(*[]uint)(unsafe.Pointer(&x)))[:len(x)]
-+}
-+
-+func Dec(b openssl.BigInt) *big.Int {
-+	if b == nil {
-+		return nil
-+	}
-+	if len(b) == 0 {
-+		return new(big.Int)
-+	}
-+	// TODO: Use unsafe.Slice((*uint)(&b[0]), len(b)) once go1.16 is no longer supported.
-+	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
-+	return new(big.Int).SetBits(x)
-+}
++var ExtractHKDF = openssl.ExtractHKDF
++var ExpandHKDF = openssl.ExpandHKDF
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 1827f76458..e436c50e22 100644
+index 1827f76458..4c5c3527a4 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
-@@ -10,6 +11,13 @@ import (
+@@ -8,8 +8,15 @@ package tls
+ 
+ import (
  	"crypto/internal/boring/fipstls"
 +	boring "crypto/internal/backend"
  )
-
+ 
 +func init() {
 +       if boring.Enabled && !boring.ExecutingTest() {
 +               fipstls.Force()
@@ -423,3 +370,307 @@ index 1827f76458..e436c50e22 100644
  // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
  func needFIPS() bool {
  	return fipstls.Required()
+@@ -17,14 +24,14 @@ func needFIPS() bool {
+ 
+ // fipsMinVersion replaces c.minVersion in FIPS-only mode.
+ func fipsMinVersion(c *Config) uint16 {
+-	// FIPS requires TLS 1.2.
++	// FIPS requires TLS 1.2 or later.
+ 	return VersionTLS12
+ }
+ 
+ // fipsMaxVersion replaces c.maxVersion in FIPS-only mode.
+ func fipsMaxVersion(c *Config) uint16 {
+-	// FIPS requires TLS 1.2.
+-	return VersionTLS12
++	// FIPS requires TLS 1.2 or later.
++	return VersionTLS13
+ }
+ 
+ // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
+diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
+index f743fc8e9f..5cf7003926 100644
+--- a/src/crypto/tls/boring_test.go
++++ b/src/crypto/tls/boring_test.go
+@@ -51,11 +51,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test("VersionTLS10", VersionTLS10, "client offered only unsupported versions")
+ 	test("VersionTLS11", VersionTLS11, "client offered only unsupported versions")
+ 	test("VersionTLS12", VersionTLS12, "")
+-	test("VersionTLS13", VersionTLS13, "client offered only unsupported versions")
++	test("VersionTLS13", VersionTLS13, "")
+ }
+ 
+ func isBoringVersion(v uint16) bool {
+-	return v == VersionTLS12
++	return v == VersionTLS12 || v == VersionTLS13
+ }
+ 
+ func isBoringCipherSuite(id uint16) bool {
+@@ -65,7 +65,9 @@ func isBoringCipherSuite(id uint16) bool {
+ 		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+ 		TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+ 		TLS_RSA_WITH_AES_128_GCM_SHA256,
+-		TLS_RSA_WITH_AES_256_GCM_SHA384:
++		TLS_RSA_WITH_AES_256_GCM_SHA384,
++		TLS_AES_128_GCM_SHA256,
++		TLS_AES_256_GCM_SHA384:
+ 		return true
+ 	}
+ 	return false
+diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
+index 9a1fa3104b..f7c64dba42 100644
+--- a/src/crypto/tls/cipher_suites.go
++++ b/src/crypto/tls/cipher_suites.go
+@@ -354,6 +354,11 @@ var defaultCipherSuitesTLS13NoAES = []uint16{
+ 	TLS_AES_256_GCM_SHA384,
+ }
+ 
++var defaultFIPSCipherSuitesTLS13 = []uint16{
++	TLS_AES_128_GCM_SHA256,
++	TLS_AES_256_GCM_SHA384,
++}
++
+ var (
+ 	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+ 	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
+index e61e3eb540..4a689ba358 100644
+--- a/src/crypto/tls/handshake_client.go
++++ b/src/crypto/tls/handshake_client.go
+@@ -10,6 +10,7 @@ import (
+ 	"crypto"
+ 	"crypto/ecdsa"
+ 	"crypto/ed25519"
++	"crypto/internal/boring"
+ 	"crypto/rsa"
+ 	"crypto/subtle"
+ 	"crypto/x509"
+@@ -127,7 +128,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
+ 
+ 	var params ecdheParameters
+ 	if hello.supportedVersions[0] == VersionTLS13 {
+-		if hasAESGCMHardwareSupport {
++		if boring.Enabled {
++			hello.cipherSuites = append(hello.cipherSuites, defaultFIPSCipherSuitesTLS13...)
++		} else if hasAESGCMHardwareSupport {
+ 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13...)
+ 		} else {
+ 			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index 380de9f6fb..02b4ac8c40 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
+ }
+ 
+ func TestAlertFlushing(t *testing.T) {
++       t.Skip("unsupported in FIPS mode, different error returned")
+ 	c, s := localPipe(t)
+ 	done := make(chan bool)
+ 
+diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
+index c7989867f5..7a60702aff 100644
+--- a/src/crypto/tls/handshake_client_tls13.go
++++ b/src/crypto/tls/handshake_client_tls13.go
+@@ -41,10 +41,6 @@ type clientHandshakeStateTLS13 struct {
+ func (hs *clientHandshakeStateTLS13) handshake() error {
+ 	c := hs.c
+ 
+-	if needFIPS() {
+-		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
+-	}
+-
+ 	// The server must not select TLS 1.3 in a renegotiation. See RFC 8446,
+ 	// sections 4.1.2 and 4.1.3.
+ 	if c.handshakes > 0 {
+diff --git a/src/crypto/tls/handshake_server_tls13.go b/src/crypto/tls/handshake_server_tls13.go
+index 03a477f7be..1ef6afceba 100644
+--- a/src/crypto/tls/handshake_server_tls13.go
++++ b/src/crypto/tls/handshake_server_tls13.go
+@@ -45,10 +45,6 @@ type serverHandshakeStateTLS13 struct {
+ func (hs *serverHandshakeStateTLS13) handshake() error {
+ 	c := hs.c
+ 
+-	if needFIPS() {
+-		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
+-	}
+-
+ 	// For an overview of the TLS 1.3 handshake, see RFC 8446, Section 2.
+ 	if err := hs.processClientHello(); err != nil {
+ 		return err
+diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
+index 314016979a..323d683788 100644
+--- a/src/crypto/tls/key_schedule.go
++++ b/src/crypto/tls/key_schedule.go
+@@ -7,6 +7,8 @@ package tls
+ import (
+ 	"crypto/elliptic"
+ 	"crypto/hmac"
++	"crypto/internal/boring"
++	"crypto/internal/boring/bbig"
+ 	"errors"
+ 	"hash"
+ 	"io"
+@@ -43,9 +45,20 @@ func (c *cipherSuiteTLS13) expandLabel(secret []byte, label string, context []by
+ 		b.AddBytes(context)
+ 	})
+ 	out := make([]byte, length)
+-	n, err := hkdf.Expand(c.hash.New, secret, hkdfLabel.BytesOrPanic()).Read(out)
+-	if err != nil || n != length {
+-		panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
++	if boring.Enabled {
++		reader, err := boring.ExpandHKDF(c.hash.New, secret, hkdfLabel.BytesOrPanic())
++		if err != nil {
++			panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
++		}
++		n, err := reader.Read(out)
++		if err != nil || n != length {
++			panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
++		}
++	} else {
++		n, err := hkdf.Expand(c.hash.New, secret, hkdfLabel.BytesOrPanic()).Read(out)
++		if err != nil || n != length {
++			panic("tls: HKDF-Expand-Label invocation failed unexpectedly")
++		}
+ 	}
+ 	return out
+ }
+@@ -63,7 +76,15 @@ func (c *cipherSuiteTLS13) extract(newSecret, currentSecret []byte) []byte {
+ 	if newSecret == nil {
+ 		newSecret = make([]byte, c.hash.Size())
+ 	}
+-	return hkdf.Extract(c.hash.New, newSecret, currentSecret)
++	if boring.Enabled {
++		ikm, err := boring.ExtractHKDF(c.hash.New, newSecret, currentSecret)
++		if err != nil {
++			panic("tls: HKDF-Extract invocation failed unexpectedly")
++		}
++		return ikm
++	} else {
++		return hkdf.Extract(c.hash.New, newSecret, currentSecret)
++	}
+ }
+ 
+ // nextTrafficSecret generates the next traffic secret, given the current one,
+@@ -129,9 +150,19 @@ func generateECDHEParameters(rand io.Reader, curveID CurveID) (ecdheParameters,
+ 
+ 	p := &nistParameters{curveID: curveID}
+ 	var err error
+-	p.privateKey, p.x, p.y, err = elliptic.GenerateKey(curve, rand)
+-	if err != nil {
+-		return nil, err
++	if boring.Enabled {
++		x, y, d, err := boring.GenerateKeyECDH(curve.Params().Name)
++		if err != nil {
++			return nil, err
++		}
++		p.x = bbig.Dec(x)
++		p.y = bbig.Dec(y)
++		p.privateKey = bbig.Dec(d).Bytes()
++	} else {
++		p.privateKey, p.x, p.y, err = elliptic.GenerateKey(curve, rand)
++		if err != nil {
++			return nil, err
++		}
+ 	}
+ 	return p, nil
+ }
+@@ -166,15 +197,28 @@ func (p *nistParameters) PublicKey() []byte {
+ 
+ func (p *nistParameters) SharedKey(peerPublicKey []byte) []byte {
+ 	curve, _ := curveForCurveID(p.curveID)
+-	// Unmarshal also checks whether the given point is on the curve.
+-	x, y := elliptic.Unmarshal(curve, peerPublicKey)
+-	if x == nil {
+-		return nil
+-	}
++	if boring.Enabled {
++		k := new(big.Int).SetBytes(p.privateKey)
++		priv, err := boring.NewPrivateKeyECDH(curve.Params().Name, bbig.Enc(p.x), bbig.Enc(p.y), bbig.Enc(k))
++		if err != nil {
++			return nil
++		}
++		sharedKey, err := boring.SharedKeyECDH(priv, peerPublicKey)
++		if err != nil {
++			return nil
++		}
++		return sharedKey
++	} else {
++		// Unmarshal also checks whether the given point is on the curve.
++		x, y := elliptic.Unmarshal(curve, peerPublicKey)
++		if x == nil {
++			return nil
++		}
+ 
+-	xShared, _ := curve.ScalarMult(x, y, p.privateKey)
+-	sharedKey := make([]byte, (curve.Params().BitSize+7)/8)
+-	return xShared.FillBytes(sharedKey)
++		xShared, _ := curve.ScalarMult(x, y, p.privateKey)
++		sharedKey := make([]byte, (curve.Params().BitSize+7)/8)
++		return xShared.FillBytes(sharedKey)
++	}
+ }
+ 
+ type x25519Parameters struct {
+diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
+index 141fdb9fbd..71434f24bc 100644
+--- a/src/go/build/deps_test.go
++++ b/src/go/build/deps_test.go
+@@ -414,19 +414,23 @@ var depsRules = `
+ 	< crypto/internal/edwards25519
+ 	< crypto/cipher;
+ 
+-	crypto/cipher,
++	fmt, crypto/cipher,
+ 	crypto/internal/boring/bcache
+ 	< crypto/internal/boring
++	< github.com/golang-fips/openssl-fips/openssl
++	< crypto/internal/backend
+ 	< crypto/boring
+ 	< crypto/aes, crypto/des, crypto/hmac, crypto/md5, crypto/rc4,
+ 	  crypto/sha1, crypto/sha256, crypto/sha512
+ 	< CRYPTO;
+ 
+-	CGO, fmt, net !< CRYPTO;
++	CGO, net !< CRYPTO;
+ 
+ 	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
+ 	CRYPTO, FMT, math/big, embed
++	< github.com/golang-fips/openssl-fips/openssl/bbig
+ 	< crypto/internal/boring/bbig
++	< crypto/internal/backend/bbig
+ 	< crypto/internal/randutil
+ 	< crypto/rand
+ 	< crypto/ed25519
+@@ -644,7 +648,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+ 
+ func findImports(pkg string) ([]string, error) {
+ 	vpkg := pkg
+-	if strings.HasPrefix(pkg, "golang.org") {
++	if strings.HasPrefix(pkg, "golang.org") || strings.HasPrefix(pkg, "github.com") {
+ 		vpkg = "vendor/" + pkg
+ 	}
+ 	dir := filepath.Join(Default.GOROOT, "src", vpkg)
+@@ -654,7 +658,7 @@ func findImports(pkg string) ([]string, error) {
+ 	}
+ 	var imports []string
+ 	var haveImport = map[string]bool{}
+-	if pkg == "crypto/internal/boring" {
++	if pkg == "crypto/internal/boring" || pkg == "github.com/golang-fips/openssl-fips/openssl" {
+ 		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
+ 	}
+ 	fset := token.NewFileSet()
+diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
+index 5a98b20253..dc25cdcfd5 100644
+--- a/src/runtime/runtime_boring.go
++++ b/src/runtime/runtime_boring.go
+@@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
+ 
+ //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
+ func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
++
++//go:linkname crypto_backend_runtime_arg0 crypto/internal/backend.runtime_arg0
++func crypto_backend_runtime_arg0() string {
++	return boring_runtime_arg0()
++}
+\ No newline at end of file


### PR DESCRIPTION
This patch enables TLS 1.3 even in FIPS mode.  To make the implementation FIPS compliant, it also delegates ECDH and HKDF operations to the FIPS certified library (openssl) through the openssl-fips package.

Fixes: #33
Fixes: #34 
Signed-off-by: Daiki Ueno <dueno@redhat.com>