### PR TITLE
Add HashSign/HashVerify

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -343,7 +343,7 @@ index 0000000000..98066f55fc
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	panic("boringcrypto: not available")
 +}
-+func HashVerifyECDSA(pub *PublicKeyECDSA, msg []byte, r, s openssl.BigInt, h crypto.Hash) bool {
++func HashVerifyECDSA(pub *PublicKeyECDSA, msg, sig []byte, h crypto.Hash) bool {
 +	panic("boringcrypto: not available")
 +}
 +func HashSignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) ([]byte, error) {

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -1,3 +1,105 @@
+diff --git a/src/crypto/ecdsa/ecdsa_hashsignverify.go b/src/crypto/ecdsa/ecdsa_hashsignverify.go
+new file mode 100644
+index 0000000000..54db9ae178
+--- /dev/null
++++ b/src/crypto/ecdsa/ecdsa_hashsignverify.go
+@@ -0,0 +1,48 @@
++package ecdsa
++
++import (
++	"crypto"
++	"crypto/internal/boring"
++	"crypto/internal/randutil"
++	"io"
++)
++
++type ecdsaSignature struct {
++   R boring.BigInt
++   S boring.BigInt
++}
++func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) ([]byte, error) {
++	randutil.MaybeReadByte(rand)
++
++	if boring.Enabled {
++		b, err := boringPrivateKey(priv)
++		if err != nil {
++			return nil, err
++		}
++		return boring.HashSignECDSA(b, msg, h)
++	}
++	boring.UnreachableExceptTests()
++
++	hash := h.New()
++	hash.Write(msg)
++	d := hash.Sum(nil)
++
++	return SignASN1(rand, priv, d)
++}
++
++func HashVerify(pub *PublicKey, msg, sig []byte, h crypto.Hash) bool {
++	if boring.Enabled {
++		bpk, err := boringPublicKey(pub)
++		if err != nil {
++			return false
++		}
++		return boring.HashVerifyECDSA(bpk, msg, sig, h)
++	}
++	boring.UnreachableExceptTests()
++
++	hash := h.New()
++	hash.Write(msg)
++	d := hash.Sum(nil)
++
++	return VerifyASN1(pub, d, sig)
++}
+diff --git a/src/crypto/ecdsa/ecdsa_hashsignverify_test.go b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
+new file mode 100644
+index 0000000000..8f95e8af1f
+--- /dev/null
++++ b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
+@@ -0,0 +1,42 @@
++package ecdsa
++
++import (
++	"crypto"
++	"crypto/internal/boring"
++	"crypto/elliptic"
++	"crypto/rand"
++	"testing"
++)
++
++func testHashSignAndHashVerify(t *testing.T, c elliptic.Curve, tag string) {
++	priv, err := GenerateKey(c, rand.Reader)
++	if priv == nil {
++		t.Fatal(err)
++	}
++
++	msg := []byte("testing")
++	h := crypto.SHA256
++	sig, err := HashSign(rand.Reader, priv, msg, h)
++	if err != nil {
++		t.Errorf("%s: error signing: %s", tag, err)
++		return
++	}
++
++	if !HashVerify(&priv.PublicKey, msg, sig, h) {
++		t.Errorf("%s: Verify failed", tag)
++	}
++
++	msg[0] ^= 0xff
++	if HashVerify(&priv.PublicKey, msg, sig, h) {
++		t.Errorf("%s: Verify should not have succeeded", tag)
++	}
++}
++func TestHashSignAndHashVerify(t *testing.T) {
++	testHashSignAndHashVerify(t, elliptic.P256(), "p256")
++
++	if testing.Short() && !boring.Enabled {
++		return
++	}
++	testHashSignAndHashVerify(t, elliptic.P384(), "p384")
++	testHashSignAndHashVerify(t, elliptic.P521(), "p521")
++}
 diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 index a0a41a50de..208aa7008a 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
@@ -92,7 +194,7 @@ new file mode 100644
 index 0000000000..98066f55fc
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,154 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -241,12 +343,18 @@ index 0000000000..98066f55fc
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	panic("boringcrypto: not available")
 +}
++func HashVerifyECDSA(pub *PublicKeyECDSA, msg []byte, r, s openssl.BigInt, h crypto.Hash) bool {
++	panic("boringcrypto: not available")
++}
++func HashSignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) ([]byte, error) {
++	panic("boringcrypto: not available")
++}
 diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
 new file mode 100644
 index 0000000000..7dc24420a0
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,103 @@
+@@ -0,0 +1,106 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -296,6 +404,7 @@ index 0000000000..7dc24420a0
 +var ExecutingTest = openssl.ExecutingTest
 +
 +const RandReader = openssl.RandReader
++type BigInt = openssl.BigInt
 +
 +var NewGCMTLS = openssl.NewGCMTLS
 +var NewSHA1 = openssl.NewSHA1
@@ -322,6 +431,8 @@ index 0000000000..7dc24420a0
 +var NewPublicKeyECDSA = openssl.NewPublicKeyECDSA
 +var SignMarshalECDSA = openssl.SignMarshalECDSA
 +var VerifyECDSA = openssl.VerifyECDSA
++var HashVerifyECDSA = openssl.HashVerifyECDSA
++var HashSignECDSA = openssl.HashSignECDSA
 +
 +type PublicKeyECDH = openssl.PublicKeyECDH
 +type PrivateKeyECDH = openssl.PrivateKeyECDH

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -1,9 +1,19 @@
+diff --git a/api/go1.19.txt b/api/go1.19.txt
+index 523f752d70..e9f2f7d173 100644
+--- a/api/go1.19.txt
++++ b/api/go1.19.txt
+@@ -290,3 +290,5 @@ pkg sync/atomic, type Uint64 struct #50860
+ pkg sync/atomic, type Uintptr struct #50860
+ pkg time, method (Duration) Abs() Duration #51414
+ pkg time, method (Time) ZoneBounds() (Time, Time) #50062
++pkg crypto/ecdsa, func HashSign(io.Reader, *PrivateKey, []uint8, crypto.Hash) ([]uint8, error) #000000
++pkg crypto/ecdsa, func HashVerify(*PublicKey, []uint8, []uint8, crypto.Hash) bool #000000
 diff --git a/src/crypto/ecdsa/ecdsa_hashsignverify.go b/src/crypto/ecdsa/ecdsa_hashsignverify.go
 new file mode 100644
 index 0000000000..54db9ae178
 --- /dev/null
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify.go
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,44 @@
 +package ecdsa
 +
 +import (
@@ -13,10 +23,6 @@ index 0000000000..54db9ae178
 +	"io"
 +)
 +
-+type ecdsaSignature struct {
-+   R boring.BigInt
-+   S boring.BigInt
-+}
 +func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) ([]byte, error) {
 +	randutil.MaybeReadByte(rand)
 +
@@ -354,7 +360,7 @@ new file mode 100644
 index 0000000000..7dc24420a0
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,106 @@
+@@ -0,0 +1,105 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -404,7 +410,6 @@ index 0000000000..7dc24420a0
 +var ExecutingTest = openssl.ExecutingTest
 +
 +const RandReader = openssl.RandReader
-+type BigInt = openssl.BigInt
 +
 +var NewGCMTLS = openssl.NewGCMTLS
 +var NewSHA1 = openssl.NewSHA1


### PR DESCRIPTION
This API was removed during the transition to 1.19. This patch adds it back. It was originally requested because the FIPS lab insisted that hashing / signing (or verifying) happen in a single openssl call.