### PR TITLE
[crypto/x509] Allow 4096 bit keys in boring mode

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -790,3 +790,29 @@ index 5a98b20253..dc25cdcfd5 100644
 +	return boring_runtime_arg0()
 +}
 \ No newline at end of file
+diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
+index 4aae90570d..42706f93c4 100644
+--- a/src/crypto/x509/boring.go
++++ b/src/crypto/x509/boring.go
+@@ -26,7 +26,7 @@ func boringAllowCert(c *Certificate) bool {
+ 	default:
+ 		return false
+ 	case *rsa.PublicKey:
+-		if size := k.N.BitLen(); size != 2048 && size != 3072 {
++		if size := k.N.BitLen(); size != 2048 && size != 3072 && size != 4096 {
+ 			return false
+ 		}
+ 	case *ecdsa.PublicKey:
+diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
+index 7010f44b32..70021f3bdd 100644
+--- a/src/crypto/x509/boring_test.go
++++ b/src/crypto/x509/boring_test.go
+@@ -54,7 +54,7 @@ type boringCertificate struct {
+ 
+ func TestBoringAllowCert(t *testing.T) {
+ 	R1 := testBoringCert(t, "R1", boringRSAKey(t, 2048), nil, boringCertCA|boringCertFIPSOK)
+-	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA)
++	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
+ 
+ 	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
+ 	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)


### PR DESCRIPTION
Upstream Go limits public keys in certificates to
2048 or 3072 bits.  This change adds support for
public keys of size 4096.