### PR TITLE
Make crypto tests work with OpenSSL 3.0 under FIPS

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -1,65 +1,5 @@
-diff --git a/src/runtime/pprof/proto_test.go b/src/runtime/pprof/proto_test.go
-index 84a051a536..a2cd97f14d 100644
---- a/src/runtime/pprof/proto_test.go
-+++ b/src/runtime/pprof/proto_test.go
-@@ -15,6 +15,7 @@ import (
- 	"os/exec"
- 	"reflect"
- 	"runtime"
-+	"strconv"
- 	"strings"
- 	"testing"
- 	"unsafe"
-@@ -95,11 +96,15 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
- 			// region of memory.
- 			t.Skipf("need 2 or more mappings, got %v", len(mprof.Mapping))
- 		}
--		addr1 = mprof.Mapping[0].Start
-+		addr1 = findAddrInExecutableSection(t, mmap, mprof.Mapping[0])
- 		map1 = mprof.Mapping[0]
-+		map1.Offset = (addr1 - map1.Start) + map1.Offset
-+		map1.Start = addr1
- 		map1.BuildID, _ = elfBuildID(map1.File)
--		addr2 = mprof.Mapping[1].Start
-+		addr2 = findAddrInExecutableSection(t, mmap, mprof.Mapping[1])
- 		map2 = mprof.Mapping[1]
-+		map2.Offset = (addr2 - map2.Start) + map2.Offset
-+		map2.Start = addr2
- 		map2.BuildID, _ = elfBuildID(map2.File)
- 	case "js":
- 		addr1 = uint64(abi.FuncPCABIInternal(f1))
-@@ -115,6 +120,29 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
- 	return
- }
- 
-+func findAddrInExecutableSection(t *testing.T, mmap []byte, m *profile.Mapping) uint64 {
-+	mappings := strings.Split(string(mmap), "\n")
-+	for _, mapping := range mappings {
-+		parts := strings.Fields(mapping)
-+		if len(parts) < 6 {
-+			continue
-+		}
-+		if !strings.Contains(parts[1], "x") {
-+			continue
-+		}
-+		addr, err := strconv.ParseUint(strings.Split(parts[0], "-")[0], 16, 64)
-+		if err != nil {
-+			t.Fatal(err)
-+		}
-+		if addr >= m.Start && addr < m.Limit {
-+			return addr
-+		}
-+	}
-+
-+	t.Error("could not find executable section in /proc/self/maps")
-+	return 0
-+}
-+
- func TestConvertCPUProfile(t *testing.T) {
- 	addr1, addr2, map1, map2 := testPCs(t)
- 
 diff --git a/api/go1.19.txt b/api/go1.19.txt
-index 523f752d70..e9f2f7d173 100644
+index 523f752d70..778e1d5a7f 100644
 --- a/api/go1.19.txt
 +++ b/api/go1.19.txt
 @@ -290,3 +290,5 @@ pkg sync/atomic, type Uint64 struct #50860
@@ -68,9 +8,27 @@ index 523f752d70..e9f2f7d173 100644
  pkg time, method (Time) ZoneBounds() (Time, Time) #50062
 +pkg crypto/ecdsa, func HashSign(io.Reader, *PrivateKey, []uint8, crypto.Hash) (*big.Int, *big.Int, error) #000000
 +pkg crypto/ecdsa, func HashVerify(*PublicKey, []uint8, *big.Int, *big.Int, crypto.Hash) bool #000000
+diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
+index a0a41a50de..208aa7008a 100644
+--- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
++++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
+@@ -21,11 +21,11 @@ go build .
+ 
+ go list -deps -f '{{.ImportPath}} {{.Dir}}' .
+ stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+-! stdout $GOROOT[/\\]src[/\\]vendor
++! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+ 
+ go list -test -deps -f '{{.ImportPath}} {{.Dir}}' .
+ stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+-! stdout $GOROOT[/\\]src[/\\]vendor
++! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
+ 
+ -- issue16333/issue16333.go --
+ package vendoring17
 diff --git a/src/crypto/ecdsa/ecdsa_hashsignverify.go b/src/crypto/ecdsa/ecdsa_hashsignverify.go
 new file mode 100644
-index 0000000000..54db9ae178
+index 0000000000..37f3a18223
 --- /dev/null
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify.go
 @@ -0,0 +1,45 @@
@@ -121,7 +79,7 @@ index 0000000000..54db9ae178
 +}
 diff --git a/src/crypto/ecdsa/ecdsa_hashsignverify_test.go b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 new file mode 100644
-index 0000000000..8f95e8af1f
+index 0000000000..d12ba2f441
 --- /dev/null
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 @@ -0,0 +1,42 @@
@@ -167,24 +125,6 @@ index 0000000000..8f95e8af1f
 +	testHashSignAndHashVerify(t, elliptic.P384(), "p384")
 +	testHashSignAndHashVerify(t, elliptic.P521(), "p521")
 +}
-diff --git a/src/cmd/go/testdata/script/gopath_std_vendor.txt b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-index a0a41a50de..208aa7008a 100644
---- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
-+++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
-@@ -21,11 +21,11 @@ go build .
- 
- go list -deps -f '{{.ImportPath}} {{.Dir}}' .
- stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
--! stdout $GOROOT[/\\]src[/\\]vendor
-+! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
- 
- go list -test -deps -f '{{.ImportPath}} {{.Dir}}' .
- stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
--! stdout $GOROOT[/\\]src[/\\]vendor
-+! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
- 
- -- issue16333/issue16333.go --
- package vendoring17
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
 index 7c5181788f..102c4e5355 100644
 --- a/src/crypto/ed25519/ed25519_test.go
@@ -258,7 +198,7 @@ new file mode 100644
 index 0000000000..e69de29bb2
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..98066f55fc
+index 0000000000..482ed6f470
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
 @@ -0,0 +1,155 @@
@@ -419,7 +359,7 @@ index 0000000000..98066f55fc
 +}
 diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
 new file mode 100644
-index 0000000000..7dc24420a0
+index 0000000000..4040c77bc1
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
 @@ -0,0 +1,105 @@
@@ -528,6 +468,305 @@ index 0000000000..7dc24420a0
 +
 +var ExtractHKDF = openssl.ExtractHKDF
 +var ExpandHKDF = openssl.ExpandHKDF
+diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
+index 69c509a771..05eac35d88 100644
+--- a/src/crypto/rsa/pkcs1v15_test.go
++++ b/src/crypto/rsa/pkcs1v15_test.go
+@@ -7,6 +7,7 @@ package rsa
+ import (
+ 	"bytes"
+ 	"crypto"
++	"crypto/internal/boring"
+ 	"crypto/rand"
+ 	"crypto/sha1"
+ 	"crypto/sha256"
+@@ -52,6 +53,10 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
+ }
+ 
+ func TestDecryptPKCS1v15(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
++	}
++
+ 	decryptionFuncs := []func([]byte) ([]byte, error){
+ 		func(ciphertext []byte) (plaintext []byte, err error) {
+ 			return DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
+@@ -76,6 +81,10 @@ func TestDecryptPKCS1v15(t *testing.T) {
+ }
+ 
+ func TestEncryptPKCS1v15(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
++	}
++
+ 	random := rand.Reader
+ 	k := (rsaPrivateKey.N.BitLen() + 7) / 8
+ 
+@@ -137,6 +146,10 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
+ }
+ 
+ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
++	}
++
+ 	for i, test := range decryptPKCS1v15SessionKeyTests {
+ 		key := []byte("FAIL")
+ 		err := DecryptPKCS1v15SessionKey(nil, rsaPrivateKey, decodeBase64(test.in), key)
+@@ -151,6 +164,10 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
+ }
+ 
+ func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
++	}
++
+ 	for i, test := range decryptPKCS1v15SessionKeyTests {
+ 		plaintext, err := rsaPrivateKey.Decrypt(rand.Reader, decodeBase64(test.in), &PKCS1v15DecryptOptions{SessionKeyLen: 4})
+ 		if err != nil {
+@@ -190,7 +207,7 @@ type signPKCS1v15Test struct {
+ //
+ //	`openssl rsautl -verify -inkey pk -in signature | hexdump -C`
+ var signPKCS1v15Tests = []signPKCS1v15Test{
+-	{"Test.\n", "a4f3fa6ea93bcdd0c57be020c1193ecbfd6f200a3d95c409769b029578fa0e336ad9a347600e40d3ae823b8c7e6bad88cc07c1d54c3a1523cbbb6d58efc362ae"},
++	{"Test.\n", "0c7c85d938862248846cba06b06ac9bfe752aafed3092c224f257855006aa35b43d101e6c8e59cbc4c20b07c81552963f189dea700e042d4b70c236a031a29a9273cc138e69dc1a5834491de4822d8cb6acf218789d2586cb0f3892236b0948ffaf8691f6fa04597caa45068f9be39b8ea8b5336a8c94e2696f872120778abcfea711e5fbf75f835f0f5204ccdd020013c2ceae25e9d1378a1d10cf86ca269eef48fee8ebb5e8dfb08f0c48d22d1a7162e080ec1f6e48541288aaaa1f2370f0688cf1786a32abed41df1d3b96b665794bf7a772743fc8b62d73901cea4569494c794a01ccc7dda0d42199f5b58739c0c0e280774b56ccf51993f5ea3d4954319"},
+ }
+ 
+ func TestSignPKCS1v15(t *testing.T) {
+@@ -199,7 +216,7 @@ func TestSignPKCS1v15(t *testing.T) {
+ 		h.Write([]byte(test.in))
+ 		digest := h.Sum(nil)
+ 
+-		s, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.SHA1, digest)
++		s, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.SHA1, digest)
+ 		if err != nil {
+ 			t.Errorf("#%d %s", i, err)
+ 		}
+@@ -219,7 +236,7 @@ func TestVerifyPKCS1v15(t *testing.T) {
+ 
+ 		sig, _ := hex.DecodeString(test.out)
+ 
+-		err := VerifyPKCS1v15(&rsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
++		err := VerifyPKCS1v15(&boringRsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
+ 		if err != nil {
+ 			t.Errorf("#%d %s", i, err)
+ 		}
+@@ -242,21 +259,25 @@ func TestUnpaddedSignature(t *testing.T) {
+ 	//
+ 	// Where "key" contains the RSA private key given at the bottom of this
+ 	// file.
+-	expectedSig := decodeBase64("pX4DR8azytjdQ1rtUiC040FjkepuQut5q2ZFX1pTjBrOVKNjgsCDyiJDGZTCNoh9qpXYbhl7iEym30BWWwuiZg==")
++	expectedSig := decodeBase64("XgDn6nJdfL/gY3eq15l9Va41/nNkDrkTlxOZYHYeFaMOW+Z4BHTCZ1LhqNBXOBK9XEyHho6okpY4rqE1zTIVX/kCGJ+jS6VRgUsHcTcpvKBYZCW84yrjE360gkntzkGxUF9FaiOGzmJKwBm1UvFgFIaYlvF+PdU0H1trBvm/RYRU42xOQRY1U+MSXgruFfINE20vPTlAG22uJ2CELrZUDykQGnrDFsEP0UqyyyiqGqxHt8E7iNYC6+xhPPC/ato9Bev08nu/U/EGH2imifSoNz/IN6h3fQClHwk1a74bPrcRsmUAAHOX2X1VKxK7IruinU8iOyoG6oFuvT+QlMnWAw==")
+ 
+-	sig, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.Hash(0), msg)
++	sig, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.Hash(0), msg)
+ 	if err != nil {
+ 		t.Fatalf("SignPKCS1v15 failed: %s", err)
+ 	}
+ 	if !bytes.Equal(sig, expectedSig) {
+ 		t.Fatalf("signature is not expected value: got %x, want %x", sig, expectedSig)
+ 	}
+-	if err := VerifyPKCS1v15(&rsaPrivateKey.PublicKey, crypto.Hash(0), msg, sig); err != nil {
++	if err := VerifyPKCS1v15(&boringRsaPrivateKey.PublicKey, crypto.Hash(0), msg, sig); err != nil {
+ 		t.Fatalf("signature failed to verify: %s", err)
+ 	}
+ }
+ 
+ func TestShortSessionKey(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
++	}
++
+ 	// This tests that attempting to decrypt a session key where the
+ 	// ciphertext is too small doesn't run outside the array bounds.
+ 	ciphertext, err := EncryptPKCS1v15(rand.Reader, &rsaPrivateKey.PublicKey, []byte{1})
+@@ -299,6 +320,51 @@ var rsaPrivateKey = &PrivateKey{
+ 	},
+ }
+ 
++
++// This key is generated with the following command:
++//
++//   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out key.pem
++//
++// In order to generate new test vectors you'll need the PEM form of this key (and s/TESTING/PRIVATE/):
++// -----BEGIN RSA TESTING KEY-----
++// MIIEogIBAAKCAQEAp5qgUIj096pw8U+AjcJucLWenR3oe+tEthXiAuqcYgslW5UU
++// lMim34U/h7NbLvbG2KJ2chUsmLtuCFaoIe/YKW5DKm3SPytK/KCBsVa+MQ7zuF/1
++// ks5p7yBqFBl6QTekMzwskt/zyDIG9f3A+38akruHNBvUgYqwbWPx4ycclQ52GSev
++// /Cfx0I68TGT5SwN/eCJ/ghq3iGAf0mX1bkVaW1seKbL49aAA94KnDCRdl813+S2R
++// EPDf2tZwlT0JpZm5QtAqthonZjkjHocZNxhkKF3XWUntE/+l6R4A+CWZlC2vmUc1
++// hJTEraksy2JUIjxAaq//FnDpIEVG/N2ofmNpaQIDAQABAoIBAAYH7h9fwkLcNvqz
++// 8+oF9k/ndSjtr9UvstYDhRG6S/zKLmK0g1xUOQ7/fjj9lvkiZ6bZd74krWlkizHR
++// HnU0KnjZLyEKeR+NSQI8q1YMi0T8JwB6MX3CIDU62x5UiV3p6OZwEqGJXf4U8MOu
++// ySAzo2rmxRd2reeobC9Pgp98I47oeqaSRwFVZRPfKk5RvfI7KRmL58BAB0XS56PA
++// PJ+3l0fB/oIV11iaBEKildxLDtrvlepQ2KPNf7Dpk0/CPRtS/jxyxIyML8tjR3F0
++// KuHplsRjTANyzW/aHddO1fnfnXsVo+0PzSPTHCbxKSu5XmChqsKoB1jM+/tJci4y
++// ST5hUXUCgYEAzfA5XEMkR/NNJMfR+FBbdfpQ1b0wqH3qtWZx/tBjKC2Y0XnDQ8ZR
++// SEWONLVZMRtTlJaHIPZ9i6anQRR5harrff0OpsKiJUGDout8ehE6eiN8ABWGNlCI
++// AiLCerVJZMDcSuDU7xsdHVIdSxYh88Z9g54vUQ4214BG/G0Qm1emV3UCgYEA0FjP
++// wq5cEGt9xDCg+oXk0bLm4Wn4FkabJH7M+oCosHHY9W1vgvv50bpNoAbaB5r1mlan
++// T6gEtkQPB2juMTnuIwRL+kvOmSKqZGlAsyrq8smTuBUv7brbybkYN3Rg51KV6u1J
++// vCdGpMYWHUNRkkQ88cr6iFPodYU+CzRR4ABif6UCgYBc0jDYb/7TW0tjD5mJJZcD
++// xw5WOE7NMuvuVT1+T6jRvDOL/yjOzH1oaMle4npQEvQKHgrMBa2ymyv5vmPDprU7
++// 9Sp8aW+yASR281MIpelIkePbGdiDdKrI46fqrPlmqzLfoRT4rKzjwVYouNIW0VlT
++// UKIdE54OZegY8IOysL/t3QKBgDZnSnECiIW9G80UCaUBO3vKZGFuA1sFutMvzSSI
++// XgQc5lNH7TtdwqESLdzgjSQ5QXK4t92j+P8DDI2Zx8DQ6K76G0DTdLImDCpGFZ/z
++// UABvxIPn/GjuRyAIlhs852Tf+seqiHt6Igc6tmGTx4QTD3rvzrW0e1ncnhPc6Jg+
++// YXoFAoGARD9OPrd4J2N+nkSWif9VOuPHvOXEczwBDJbsAGrOW1kTbDStF0OIVOt0
++// Ukj+mnnL8ZNyVLgTrZDRfXvlA94EbPK5/rMAYwjMlXHP8R22ts3eDMNUdw0/Zl1g
++// QOhL8wXZcdwHKsONy55kZHo8pmneqi9EnqqLGguLwx5WIMzWvZ8=
++// -----END RSA TESTING KEY-----
++var boringRsaPrivateKey = &PrivateKey{
++	PublicKey: PublicKey{
++		N: fromBase10("21158045964626271357192122217374656030758659027828186070945904292001900400536015683616588162432995042444433048358489684754391937856768687035719252953024200424710141144247332111111703450451053746470714834263970345645429072182468402024496704681563920755701016821908901551953007428010372679515325239834996680088335364047952157190852800612876331418656069309925009888436309603986985085994522668542367909534919143332035879812534342880780397552183153129074979881038274141387521146813437241354454755076987809231514974999721446583492285447433481905074857761363232069067710471781475338676103917736574576264372309657208790149481"),
++		E: 65537,
++	},
++	D: fromBase10("761340340511160175596965412196526886865993372482350730149506062172718946847796801591296809955561141932718681604153505639135828424412541864931030231418425021767439619656396706456340306422726055474229263742664572190035142125430003037585933958150329067887329644632294232035234749334047352968048823517110653841610552935776850272326662981899080407723586223365381844237920705656687458814241284694808178926597606445541251131238479373288091835422103855191540510255449923931942356040157416183921500123257314690876170989779091557025781299703525522541564460824444942813697278129203778499396891927458901143348340382342458724725"),
++	Primes: []*big.Int{
++		fromBase10("144614845075019407477413542397453717313067325100413366253445573263534965103596714687177264872359318890824353359027245467187809258188745722502749049155303133577880462309749004261724896311777040275474974736908034246705034289232466323779271534051780280366551238605398407358839369487962557838147775245147196249973"),
++		fromBase10("146306182837940795154243491672545598732731521261772425577071902398494756400761181229877966908959767779942799478853764354255505873530749881845000716071915494302715554511619294255599209521952152229250381623079574375248555498847701822870266575429060940749806104053368129657146195126647000200158517816035847077797"),
++	},
++}
++
+ func TestShortPKCS1v15Signature(t *testing.T) {
+ 	pub := &PublicKey{
+ 		E: 65537,
+diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
+index 51f9760187..93bbc26bd0 100644
+--- a/src/crypto/rsa/pss_test.go
++++ b/src/crypto/rsa/pss_test.go
+@@ -9,6 +9,7 @@ import (
+ 	"bytes"
+ 	"compress/bzip2"
+ 	"crypto"
++	"crypto/internal/boring"
+ 	"crypto/rand"
+ 	"crypto/sha1"
+ 	"crypto/sha256"
+@@ -76,6 +77,9 @@ func TestEMSAPSS(t *testing.T) {
+ // TestPSSGolden tests all the test vectors in pss-vect.txt from
+ // ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1-vec.zip
+ func TestPSSGolden(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PSS test with BoringCrypto: SHA-1 not allowed")
++	}
+ 	inFile, err := os.Open("testdata/pss-vect.txt.bz2")
+ 	if err != nil {
+ 		t.Fatalf("Failed to open input file: %s", err)
+@@ -167,6 +171,10 @@ func TestPSSGolden(t *testing.T) {
+ // TestPSSOpenSSL ensures that we can verify a PSS signature from OpenSSL with
+ // the default options. OpenSSL sets the salt length to be maximal.
+ func TestPSSOpenSSL(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PSS test with BoringCrypto: too short key")
++	}
++
+ 	hash := crypto.SHA256
+ 	h := hash.New()
+ 	h.Write([]byte("testing"))
+@@ -194,10 +202,15 @@ func TestPSSNilOpts(t *testing.T) {
+ 	h.Write([]byte("testing"))
+ 	hashed := h.Sum(nil)
+ 
++	// Shouldn't this check return value?
+ 	SignPSS(rand.Reader, rsaPrivateKey, hash, hashed, nil)
+ }
+ 
+ func TestPSSSigning(t *testing.T) {
++	if boring.Enabled {
++		t.Skip("skipping PSS test with BoringCrypto: too short key")
++	}
++
+ 	var saltLengthCombinations = []struct {
+ 		signSaltLength, verifySaltLength int
+ 		good                             bool
+@@ -233,7 +246,7 @@ func TestPSSSigning(t *testing.T) {
+ }
+ 
+ func TestSignWithPSSSaltLengthAuto(t *testing.T) {
+-	key, err := GenerateKey(rand.Reader, 513)
++	key, err := GenerateKey(rand.Reader, 2048)
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
+diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
+index 766d9a954f..dc502cae8f 100644
+--- a/src/crypto/rsa/rsa_test.go
++++ b/src/crypto/rsa/rsa_test.go
+@@ -26,6 +26,10 @@ func TestKeyGeneration(t *testing.T) {
+ 		if bits := priv.N.BitLen(); bits != size {
+ 			t.Errorf("key too short (%d vs %d)", bits, size)
+ 		}
++		if boring.Enabled && size < 1024 {
++			t.Logf("skipping short key with BoringCrypto: %d", size)
++			continue;
++		}
+ 		testKeyBasics(t, priv)
+ 		if testing.Short() {
+ 			break
+@@ -115,16 +119,23 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
+ 	}
+ 
+ 	if boring.Enabled {
+-		// Cannot call encrypt/decrypt directly. Test via PKCS1v15.
++		// Cannot call encrypt/decrypt with raw RSA. Test via
++		// OAEP if possible (i.e., key size is equal to or
++		// longer than 2048 bits).
++		if bits := priv.N.BitLen(); bits < 2048 {
++			t.Logf("skipping short key with BoringCrypto: %d", bits)
++			return;
++		}
++		sha256 := sha256.New()
+ 		msg := []byte("hi!")
+-		enc, err := EncryptPKCS1v15(rand.Reader, &priv.PublicKey, msg)
++		enc, err := EncryptOAEP(sha256, rand.Reader, &priv.PublicKey, msg, nil)
+ 		if err != nil {
+-			t.Errorf("EncryptPKCS1v15: %v", err)
++			t.Errorf("EncryptOAEP: %v", err)
+ 			return
+ 		}
+-		dec, err := DecryptPKCS1v15(rand.Reader, priv, enc)
++		dec, err := DecryptOAEP(sha256, rand.Reader, priv, enc, nil)
+ 		if err != nil {
+-			t.Errorf("DecryptPKCS1v15: %v", err)
++			t.Errorf("DecryptOAEP: %v", err)
+ 			return
+ 		}
+ 		if !bytes.Equal(dec, msg) {
+@@ -253,6 +264,10 @@ func TestEncryptOAEP(t *testing.T) {
+ 	n := new(big.Int)
+ 	for i, test := range testEncryptOAEPData {
+ 		n.SetString(test.modulus, 16)
++		if boring.Enabled && n.BitLen() < 2048 {
++			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
++			continue
++		}
+ 		public := PublicKey{N: n, E: test.e}
+ 
+ 		for j, message := range test.msgs {
+@@ -276,6 +291,10 @@ func TestDecryptOAEP(t *testing.T) {
+ 	d := new(big.Int)
+ 	for i, test := range testEncryptOAEPData {
+ 		n.SetString(test.modulus, 16)
++		if boring.Enabled && n.BitLen() < 2048 {
++			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
++			continue
++		}
+ 		d.SetString(test.d, 16)
+ 		private := new(PrivateKey)
+ 		private.PublicKey = PublicKey{N: n, E: test.e}
+@@ -309,6 +328,10 @@ func TestEncryptDecryptOAEP(t *testing.T) {
+ 	d := new(big.Int)
+ 	for i, test := range testEncryptOAEPData {
+ 		n.SetString(test.modulus, 16)
++		if boring.Enabled && n.BitLen() < 2048 {
++			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
++			continue
++		}
+ 		d.SetString(test.d, 16)
+ 		priv := new(PrivateKey)
+ 		priv.PublicKey = PublicKey{N: n, E: test.e}
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
 index 1827f76458..4c5c3527a4 100644
 --- a/src/crypto/tls/boring.go
@@ -567,10 +806,18 @@ index 1827f76458..4c5c3527a4 100644
  
  // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index f743fc8e9f..9fec2c8eb8 100644
+index f743fc8e9f..19ba03531c 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
-@@ -51,11 +51,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+@@ -9,6 +9,7 @@ package tls
+ import (
+ 	"crypto/ecdsa"
+ 	"crypto/elliptic"
++	"crypto/internal/boring"
+ 	"crypto/internal/boring/fipstls"
+ 	"crypto/rand"
+ 	"crypto/rsa"
+@@ -51,11 +52,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
  	test("VersionTLS10", VersionTLS10, "client offered only unsupported versions")
  	test("VersionTLS11", VersionTLS11, "client offered only unsupported versions")
  	test("VersionTLS12", VersionTLS12, "")
@@ -584,7 +831,7 @@ index f743fc8e9f..9fec2c8eb8 100644
  }
  
  func isBoringCipherSuite(id uint16) bool {
-@@ -65,7 +65,9 @@ func isBoringCipherSuite(id uint16) bool {
+@@ -65,7 +66,9 @@ func isBoringCipherSuite(id uint16) bool {
  		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
  		TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
  		TLS_RSA_WITH_AES_128_GCM_SHA256,
@@ -595,7 +842,7 @@ index f743fc8e9f..9fec2c8eb8 100644
  		return true
  	}
  	return false
-@@ -311,7 +313,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -311,7 +314,7 @@ func TestBoringCertAlgs(t *testing.T) {
  	// Set up some roots, intermediate CAs, and leaf certs with various algorithms.
  	// X_Y is X signed by Y.
  	R1 := boringCert(t, "R1", boringRSAKey(t, 2048), nil, boringCertCA|boringCertFIPSOK)
@@ -604,6 +851,100 @@ index f743fc8e9f..9fec2c8eb8 100644
  
  	M1_R1 := boringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
  	M2_R1 := boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
+@@ -322,7 +325,7 @@ func TestBoringCertAlgs(t *testing.T) {
+ 	I_M2 := boringCert(t, "I_M2", I_R1.key, M2_R1, boringCertCA|boringCertFIPSOK)
+ 
+ 	L1_I := boringCert(t, "L1_I", boringECDSAKey(t, elliptic.P384()), I_R1, boringCertLeaf|boringCertFIPSOK)
+-	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf)
++	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf|boringCertNotBoring)
+ 
+ 	// client verifying server cert
+ 	testServerCert := func(t *testing.T, desc string, pool *x509.CertPool, key interface{}, list [][]byte, ok bool) {
+@@ -361,6 +364,11 @@ func TestBoringCertAlgs(t *testing.T) {
+ 		serverConfig := testConfig.Clone()
+ 		serverConfig.ClientCAs = pool
+ 		serverConfig.ClientAuth = RequireAndVerifyClientCert
++		if boring.Enabled {
++			serverConfig.Certificates[0].Certificate = [][]byte{testRSA2048Certificate}
++			serverConfig.Certificates[0].PrivateKey = testRSA2048PrivateKey
++			serverConfig.BuildNameToCertificate()
++		}
+ 
+ 		_, serverErr := boringHandshake(t, clientConfig, serverConfig)
+ 
+@@ -383,8 +391,8 @@ func TestBoringCertAlgs(t *testing.T) {
+ 	// exhaustive test with computed answers.
+ 	r1pool := x509.NewCertPool()
+ 	r1pool.AddCert(R1.cert)
+-	testServerCert(t, "basic", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, true)
+-	testClientCert(t, "basic (client cert)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, true)
++	testServerCert(t, "basic", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, !(L2_I.notBoring && boring.Enabled))
++	testClientCert(t, "basic (client cert)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, !(L2_I.notBoring && boring.Enabled))
+ 	fipstls.Force()
+ 	testServerCert(t, "basic (fips)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
+ 	testClientCert(t, "basic (fips, client cert)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
+@@ -405,7 +413,7 @@ func TestBoringCertAlgs(t *testing.T) {
+ 			leaf = L2_I
+ 		}
+ 		for i := 0; i < 64; i++ {
+-			reachable := map[string]bool{leaf.parentOrg: true}
++			reachable := map[string]bool{leaf.parentOrg: !(leaf.notBoring && boring.Enabled)}
+ 			reachableFIPS := map[string]bool{leaf.parentOrg: leaf.fipsOK}
+ 			list := [][]byte{leaf.der}
+ 			listName := leaf.name
+@@ -413,7 +421,7 @@ func TestBoringCertAlgs(t *testing.T) {
+ 				if cond != 0 {
+ 					list = append(list, c.der)
+ 					listName += "," + c.name
+-					if reachable[c.org] {
++					if reachable[c.org] && !(c.notBoring && boring.Enabled) {
+ 						reachable[c.parentOrg] = true
+ 					}
+ 					if reachableFIPS[c.org] && c.fipsOK {
+@@ -437,7 +445,7 @@ func TestBoringCertAlgs(t *testing.T) {
+ 					if cond != 0 {
+ 						rootName += "," + c.name
+ 						pool.AddCert(c.cert)
+-						if reachable[c.org] {
++						if reachable[c.org] && !(c.notBoring && boring.Enabled) {
+ 							shouldVerify = true
+ 						}
+ 						if reachableFIPS[c.org] && c.fipsOK {
+@@ -463,6 +471,7 @@ const (
+ 	boringCertCA = iota
+ 	boringCertLeaf
+ 	boringCertFIPSOK = 0x80
++	boringCertNotBoring = 0x100
+ )
+ 
+ func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
+@@ -489,6 +498,7 @@ type boringCertificate struct {
+ 	cert      *x509.Certificate
+ 	key       interface{}
+ 	fipsOK    bool
++	notBoring bool
+ }
+ 
+ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertificate, mode int) *boringCertificate {
+@@ -510,7 +520,7 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
+ 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+ 		BasicConstraintsValid: true,
+ 	}
+-	if mode&^boringCertFIPSOK == boringCertLeaf {
++	if mode&^(boringCertFIPSOK|boringCertNotBoring) == boringCertLeaf {
+ 		tmpl.DNSNames = []string{"example.com"}
+ 	} else {
+ 		tmpl.IsCA = true
+@@ -547,7 +557,8 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
+ 	}
+ 
+ 	fipsOK := mode&boringCertFIPSOK != 0
+-	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK}
++	notBoring := mode&boringCertNotBoring != 0
++	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK, notBoring}
+ }
+ 
+ // A self-signed test certificate with an RSA key of size 2048, for testing
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 9a1fa3104b..f7c64dba42 100644
 --- a/src/crypto/tls/cipher_suites.go
@@ -791,6 +1132,151 @@ index 314016979a..323d683788 100644
  }
  
  type x25519Parameters struct {
+diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
+index 4aae90570d..42706f93c4 100644
+--- a/src/crypto/x509/boring.go
++++ b/src/crypto/x509/boring.go
+@@ -26,7 +26,7 @@ func boringAllowCert(c *Certificate) bool {
+ 	default:
+ 		return false
+ 	case *rsa.PublicKey:
+-		if size := k.N.BitLen(); size != 2048 && size != 3072 {
++		if size := k.N.BitLen(); size != 2048 && size != 3072 && size != 4096 {
+ 			return false
+ 		}
+ 	case *ecdsa.PublicKey:
+diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
+index 7010f44b32..70021f3bdd 100644
+--- a/src/crypto/x509/boring_test.go
++++ b/src/crypto/x509/boring_test.go
+@@ -54,7 +54,7 @@ type boringCertificate struct {
+ 
+ func TestBoringAllowCert(t *testing.T) {
+ 	R1 := testBoringCert(t, "R1", boringRSAKey(t, 2048), nil, boringCertCA|boringCertFIPSOK)
+-	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA)
++	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
+ 
+ 	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
+ 	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
+diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
+index b1cdabba28..f2d7a2bd6e 100644
+--- a/src/crypto/x509/x509_test.go
++++ b/src/crypto/x509/x509_test.go
+@@ -11,6 +11,7 @@ import (
+ 	"crypto/ecdsa"
+ 	"crypto/ed25519"
+ 	"crypto/elliptic"
++	"crypto/internal/boring"
+ 	"crypto/rand"
+ 	"crypto/rsa"
+ 	_ "crypto/sha256"
+@@ -117,32 +118,54 @@ func TestParsePKIXPublicKey(t *testing.T) {
+ 	})
+ }
+ 
++// This public key is extracted from pemPrivateKey defined below with
++// the following command:
++//
++//   openssl pkey -pubout -in key.pem
++//
+ var pemPublicKey = `-----BEGIN PUBLIC KEY-----
+-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3VoPN9PKUjKFLMwOge6+
+-wnDi8sbETGIx2FKXGgqtAKpzmem53kRGEQg8WeqRmp12wgp74TGpkEXsGae7RS1k
+-enJCnma4fii+noGH7R0qKgHvPrI2Bwa9hzsH8tHxpyM3qrXslOmD45EH9SxIDUBJ
+-FehNdaPbLP1gFyahKMsdfxFJLUvbUycuZSJ2ZnIgeVxwm4qbSvZInL9Iu4FzuPtg
+-fINKcbbovy1qq4KvPIrXzhbY3PWDc6btxCf3SE0JdE1MCPThntB62/bLMSQ7xdDR
+-FF53oIpvxe/SCOymfWq/LW849Ytv3Xwod0+wzAP8STXG4HSELS4UedPYeHJJJYcZ
+-+QIDAQAB
++MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp5qgUIj096pw8U+AjcJu
++cLWenR3oe+tEthXiAuqcYgslW5UUlMim34U/h7NbLvbG2KJ2chUsmLtuCFaoIe/Y
++KW5DKm3SPytK/KCBsVa+MQ7zuF/1ks5p7yBqFBl6QTekMzwskt/zyDIG9f3A+38a
++kruHNBvUgYqwbWPx4ycclQ52GSev/Cfx0I68TGT5SwN/eCJ/ghq3iGAf0mX1bkVa
++W1seKbL49aAA94KnDCRdl813+S2REPDf2tZwlT0JpZm5QtAqthonZjkjHocZNxhk
++KF3XWUntE/+l6R4A+CWZlC2vmUc1hJTEraksy2JUIjxAaq//FnDpIEVG/N2ofmNp
++aQIDAQAB
+ -----END PUBLIC KEY-----
+ `
+ 
++// This key is generated with the following command:
++//
++//   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out key.pem
++//   openssl pkey -traditional -in key.pem > key-traditional.pem
++//
+ var pemPrivateKey = testingKey(`
+ -----BEGIN RSA TESTING KEY-----
+-MIICXAIBAAKBgQCxoeCUW5KJxNPxMp+KmCxKLc1Zv9Ny+4CFqcUXVUYH69L3mQ7v
+-IWrJ9GBfcaA7BPQqUlWxWM+OCEQZH1EZNIuqRMNQVuIGCbz5UQ8w6tS0gcgdeGX7
+-J7jgCQ4RK3F/PuCM38QBLaHx988qG8NMc6VKErBjctCXFHQt14lerd5KpQIDAQAB
+-AoGAYrf6Hbk+mT5AI33k2Jt1kcweodBP7UkExkPxeuQzRVe0KVJw0EkcFhywKpr1
+-V5eLMrILWcJnpyHE5slWwtFHBG6a5fLaNtsBBtcAIfqTQ0Vfj5c6SzVaJv0Z5rOd
+-7gQF6isy3t3w9IF3We9wXQKzT6q5ypPGdm6fciKQ8RnzREkCQQDZwppKATqQ41/R
+-vhSj90fFifrGE6aVKC1hgSpxGQa4oIdsYYHwMzyhBmWW9Xv/R+fPyr8ZwPxp2c12
+-33QwOLPLAkEA0NNUb+z4ebVVHyvSwF5jhfJxigim+s49KuzJ1+A2RaSApGyBZiwS
+-rWvWkB471POAKUYt5ykIWVZ83zcceQiNTwJBAMJUFQZX5GDqWFc/zwGoKkeR49Yi
+-MTXIvf7Wmv6E++eFcnT461FlGAUHRV+bQQXGsItR/opIG7mGogIkVXa3E1MCQARX
+-AAA7eoZ9AEHflUeuLn9QJI/r0hyQQLEtrpwv6rDT1GCWaLII5HJ6NUFVf4TTcqxo
+-6vdM4QGKTJoO+SaCyP0CQFdpcxSAuzpFcKv0IlJ8XzS/cy+mweCMwyJ1PFEc4FX6
+-wg/HcAJWY60xZTJDFN+Qfx8ZQvBEin6c2/h+zZi5IVY=
++MIIEogIBAAKCAQEAp5qgUIj096pw8U+AjcJucLWenR3oe+tEthXiAuqcYgslW5UU
++lMim34U/h7NbLvbG2KJ2chUsmLtuCFaoIe/YKW5DKm3SPytK/KCBsVa+MQ7zuF/1
++ks5p7yBqFBl6QTekMzwskt/zyDIG9f3A+38akruHNBvUgYqwbWPx4ycclQ52GSev
++/Cfx0I68TGT5SwN/eCJ/ghq3iGAf0mX1bkVaW1seKbL49aAA94KnDCRdl813+S2R
++EPDf2tZwlT0JpZm5QtAqthonZjkjHocZNxhkKF3XWUntE/+l6R4A+CWZlC2vmUc1
++hJTEraksy2JUIjxAaq//FnDpIEVG/N2ofmNpaQIDAQABAoIBAAYH7h9fwkLcNvqz
++8+oF9k/ndSjtr9UvstYDhRG6S/zKLmK0g1xUOQ7/fjj9lvkiZ6bZd74krWlkizHR
++HnU0KnjZLyEKeR+NSQI8q1YMi0T8JwB6MX3CIDU62x5UiV3p6OZwEqGJXf4U8MOu
++ySAzo2rmxRd2reeobC9Pgp98I47oeqaSRwFVZRPfKk5RvfI7KRmL58BAB0XS56PA
++PJ+3l0fB/oIV11iaBEKildxLDtrvlepQ2KPNf7Dpk0/CPRtS/jxyxIyML8tjR3F0
++KuHplsRjTANyzW/aHddO1fnfnXsVo+0PzSPTHCbxKSu5XmChqsKoB1jM+/tJci4y
++ST5hUXUCgYEAzfA5XEMkR/NNJMfR+FBbdfpQ1b0wqH3qtWZx/tBjKC2Y0XnDQ8ZR
++SEWONLVZMRtTlJaHIPZ9i6anQRR5harrff0OpsKiJUGDout8ehE6eiN8ABWGNlCI
++AiLCerVJZMDcSuDU7xsdHVIdSxYh88Z9g54vUQ4214BG/G0Qm1emV3UCgYEA0FjP
++wq5cEGt9xDCg+oXk0bLm4Wn4FkabJH7M+oCosHHY9W1vgvv50bpNoAbaB5r1mlan
++T6gEtkQPB2juMTnuIwRL+kvOmSKqZGlAsyrq8smTuBUv7brbybkYN3Rg51KV6u1J
++vCdGpMYWHUNRkkQ88cr6iFPodYU+CzRR4ABif6UCgYBc0jDYb/7TW0tjD5mJJZcD
++xw5WOE7NMuvuVT1+T6jRvDOL/yjOzH1oaMle4npQEvQKHgrMBa2ymyv5vmPDprU7
++9Sp8aW+yASR281MIpelIkePbGdiDdKrI46fqrPlmqzLfoRT4rKzjwVYouNIW0VlT
++UKIdE54OZegY8IOysL/t3QKBgDZnSnECiIW9G80UCaUBO3vKZGFuA1sFutMvzSSI
++XgQc5lNH7TtdwqESLdzgjSQ5QXK4t92j+P8DDI2Zx8DQ6K76G0DTdLImDCpGFZ/z
++UABvxIPn/GjuRyAIlhs852Tf+seqiHt6Igc6tmGTx4QTD3rvzrW0e1ncnhPc6Jg+
++YXoFAoGARD9OPrd4J2N+nkSWif9VOuPHvOXEczwBDJbsAGrOW1kTbDStF0OIVOt0
++Ukj+mnnL8ZNyVLgTrZDRfXvlA94EbPK5/rMAYwjMlXHP8R22ts3eDMNUdw0/Zl1g
++QOhL8wXZcdwHKsONy55kZHo8pmneqi9EnqqLGguLwx5WIMzWvZ8=
+ -----END RSA TESTING KEY-----
+ `)
+ 
+@@ -195,13 +218,13 @@ func bigFromHexString(s string) *big.Int {
+ 
+ var rsaPrivateKey = &rsa.PrivateKey{
+ 	PublicKey: rsa.PublicKey{
+-		N: bigFromString("124737666279038955318614287965056875799409043964547386061640914307192830334599556034328900586693254156136128122194531292927142396093148164407300419162827624945636708870992355233833321488652786796134504707628792159725681555822420087112284637501705261187690946267527866880072856272532711620639179596808018872997"),
++		N: bigFromString("21158045964626271357192122217374656030758659027828186070945904292001900400536015683616588162432995042444433048358489684754391937856768687035719252953024200424710141144247332111111703450451053746470714834263970345645429072182468402024496704681563920755701016821908901551953007428010372679515325239834996680088335364047952157190852800612876331418656069309925009888436309603986985085994522668542367909534919143332035879812534342880780397552183153129074979881038274141387521146813437241354454755076987809231514974999721446583492285447433481905074857761363232069067710471781475338676103917736574576264372309657208790149481"),
+ 		E: 65537,
+ 	},
+-	D: bigFromString("69322600686866301945688231018559005300304807960033948687567105312977055197015197977971637657636780793670599180105424702854759606794705928621125408040473426339714144598640466128488132656829419518221592374964225347786430566310906679585739468938549035854760501049443920822523780156843263434219450229353270690889"),
++	D: bigFromString("761340340511160175596965412196526886865993372482350730149506062172718946847796801591296809955561141932718681604153505639135828424412541864931030231418425021767439619656396706456340306422726055474229263742664572190035142125430003037585933958150329067887329644632294232035234749334047352968048823517110653841610552935776850272326662981899080407723586223365381844237920705656687458814241284694808178926597606445541251131238479373288091835422103855191540510255449923931942356040157416183921500123257314690876170989779091557025781299703525522541564460824444942813697278129203778499396891927458901143348340382342458724725"),
+ 	Primes: []*big.Int{
+-		bigFromString("11405025354575369741595561190164746858706645478381139288033759331174478411254205003127028642766986913445391069745480057674348716675323735886284176682955723"),
+-		bigFromString("10937079261204603443118731009201819560867324167189758120988909645641782263430128449826989846631183550578761324239709121189827307416350485191350050332642639"),
++		bigFromString("144614845075019407477413542397453717313067325100413366253445573263534965103596714687177264872359318890824353359027245467187809258188745722502749049155303133577880462309749004261724896311777040275474974736908034246705034289232466323779271534051780280366551238605398407358839369487962557838147775245147196249973"),
++		bigFromString("146306182837940795154243491672545598732731521261772425577071902398494756400761181229877966908959767779942799478853764354255505873530749881845000716071915494302715554511619294255599209521952152229250381623079574375248555498847701822870266575429060940749806104053368129657146195126647000200158517816035847077797"),
+ 	},
+ }
+ 
+@@ -614,6 +637,13 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
+ 	extraExtensionData := []byte("extra extension")
+ 
+ 	for _, test := range tests {
++		if boring.Enabled && test.sigAlgo.isRSAPSS() {
++			key, _ := test.priv.(*rsa.PrivateKey)
++			if key.PublicKey.N.BitLen() < 2048 {
++				t.Logf("skipping short key with BoringCrypto: %d", key.PublicKey.N.BitLen())
++				continue
++			}
++		}
+ 		commonName := "test.example.com"
+ 		template := Certificate{
+ 			SerialNumber: big.NewInt(1),
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index 141fdb9fbd..d8e81d921d 100644
 --- a/src/go/build/deps_test.go
@@ -847,6 +1333,66 @@ index 141fdb9fbd..d8e81d921d 100644
  		haveImport["C"] = true // kludge: prevent C from appearing in crypto/internal/boring imports
  	}
  	fset := token.NewFileSet()
+diff --git a/src/runtime/pprof/proto_test.go b/src/runtime/pprof/proto_test.go
+index 84a051a536..a2cd97f14d 100644
+--- a/src/runtime/pprof/proto_test.go
++++ b/src/runtime/pprof/proto_test.go
+@@ -15,6 +15,7 @@ import (
+ 	"os/exec"
+ 	"reflect"
+ 	"runtime"
++	"strconv"
+ 	"strings"
+ 	"testing"
+ 	"unsafe"
+@@ -95,11 +96,15 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
+ 			// region of memory.
+ 			t.Skipf("need 2 or more mappings, got %v", len(mprof.Mapping))
+ 		}
+-		addr1 = mprof.Mapping[0].Start
++		addr1 = findAddrInExecutableSection(t, mmap, mprof.Mapping[0])
+ 		map1 = mprof.Mapping[0]
++		map1.Offset = (addr1 - map1.Start) + map1.Offset
++		map1.Start = addr1
+ 		map1.BuildID, _ = elfBuildID(map1.File)
+-		addr2 = mprof.Mapping[1].Start
++		addr2 = findAddrInExecutableSection(t, mmap, mprof.Mapping[1])
+ 		map2 = mprof.Mapping[1]
++		map2.Offset = (addr2 - map2.Start) + map2.Offset
++		map2.Start = addr2
+ 		map2.BuildID, _ = elfBuildID(map2.File)
+ 	case "js":
+ 		addr1 = uint64(abi.FuncPCABIInternal(f1))
+@@ -115,6 +120,29 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
+ 	return
+ }
+ 
++func findAddrInExecutableSection(t *testing.T, mmap []byte, m *profile.Mapping) uint64 {
++	mappings := strings.Split(string(mmap), "\n")
++	for _, mapping := range mappings {
++		parts := strings.Fields(mapping)
++		if len(parts) < 6 {
++			continue
++		}
++		if !strings.Contains(parts[1], "x") {
++			continue
++		}
++		addr, err := strconv.ParseUint(strings.Split(parts[0], "-")[0], 16, 64)
++		if err != nil {
++			t.Fatal(err)
++		}
++		if addr >= m.Start && addr < m.Limit {
++			return addr
++		}
++	}
++
++	t.Error("could not find executable section in /proc/self/maps")
++	return 0
++}
++
+ func TestConvertCPUProfile(t *testing.T) {
+ 	addr1, addr2, map1, map2 := testPCs(t)
+ 
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253..dc25cdcfd5 100644
 --- a/src/runtime/runtime_boring.go
@@ -861,29 +1407,3 @@ index 5a98b20253..dc25cdcfd5 100644
 +	return boring_runtime_arg0()
 +}
 \ No newline at end of file
-diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
-index 4aae90570d..42706f93c4 100644
---- a/src/crypto/x509/boring.go
-+++ b/src/crypto/x509/boring.go
-@@ -26,7 +26,7 @@ func boringAllowCert(c *Certificate) bool {
- 	default:
- 		return false
- 	case *rsa.PublicKey:
--		if size := k.N.BitLen(); size != 2048 && size != 3072 {
-+		if size := k.N.BitLen(); size != 2048 && size != 3072 && size != 4096 {
- 			return false
- 		}
- 	case *ecdsa.PublicKey:
-diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 7010f44b32..70021f3bdd 100644
---- a/src/crypto/x509/boring_test.go
-+++ b/src/crypto/x509/boring_test.go
-@@ -54,7 +54,7 @@ type boringCertificate struct {
- 
- func TestBoringAllowCert(t *testing.T) {
- 	R1 := testBoringCert(t, "R1", boringRSAKey(t, 2048), nil, boringCertCA|boringCertFIPSOK)
--	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA)
-+	R2 := testBoringCert(t, "R2", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
- 
- 	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
- 	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)


### PR DESCRIPTION
There are a few restrictions enforced when OpenSSL 3.0 is used under FIPS mode, that are incompatible with the Go tests, namely:

- For creating signature, encrypting, and decrypting, RSA key size must be equal to or longer than 2048 bits
- For verifying signature, RSA key size must be equal to or longer than 1024 bits
- PKCS#1 v1.5 is not supported for encryption and decryption (signing and verification are still allowed)

This either skips the relevant tests or increases key size used for testing.

This should fix the test failures in `crypto` tests as mentioned in golang-fips/openssl-fips#25.