### PR TITLE
Allow setup using tags and commits

### DIFF
--- a/scripts/setup-go-submodule.sh
+++ b/scripts/setup-go-submodule.sh
@@ -2,13 +2,17 @@
 
 set -ex
 
-BRANCH=${1}
+GIT_REF=${1}
 
-if [ -z "${BRANCH}" ]; then
-    echo "You must supply a branch for the Go submodule (for example dev.boringcrypto.go1.18)"
+if [ -z "${GIT_REF}" ]; then
+    echo "You must supply a branch, tag, or commit for the Go submodule (for example release-branch.go1.19)"
     exit 1
 fi
 
-git submodule add --force -b "${BRANCH}" https://github.com/golang/go.git
+git submodule add --force https://github.com/golang/go.git
 git submodule update
+
+pushd go
+git checkout ${GIT_REF}
+popd
 


### PR DESCRIPTION
Currently, the setup scripts only support targeting branches of upstream Go.  This can cause previously working versions of the setup to break out from under us whenever those branches are updated by the Go
community.

This commit adjusts the setup scripts to support targeting tags and commits, allowing users to target upstream Go refs which are known to be fully compatible with the golang-fips setup process.