### PR TITLE
Pin dependency versions

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,0 +1,5 @@
+{
+	"github.com/golang-fips/go":           "main",
+	"github.com/golang-fips/openssl-fips": "master",
+	"github.com/golang/go":                "master"
+}

--- a/scripts/create-secondary-patch.sh
+++ b/scripts/create-secondary-patch.sh
@@ -27,7 +27,11 @@ rm src/crypto/boring/boring_test.go
 
 # Add new openssl backend to module and vendor it.
 cd src
-go get github.com/golang-fips/openssl-fips
+SCRIPT_DIR=$(readlink -f $(dirname $0))
+CONFIG_DIR=$(readlink -f $(dirname $0)/../config)
+OPENSSL_FIPS_REF=$(go run ${SCRIPT_DIR}/versions.go ${CONFIG_DIR}/versions.json \
+			github.com/golang-fips/openssl-fips)
+go get github.com/golang-fips/openssl-fips@${OPENSSL_FIPS_REF}
 
 replace="${1}"
 if [ -n "${replace}" ]; then

--- a/scripts/setup-go-submodule.sh
+++ b/scripts/setup-go-submodule.sh
@@ -3,10 +3,15 @@
 set -ex
 
 GIT_REF=${1}
+SCRIPT_DIR=$(readlink -f $(dirname $0))
+CONFIG_DIR=$(readlink -f $(dirname $0)/../config)
 
 if [ -z "${GIT_REF}" ]; then
-    echo "You must supply a branch, tag, or commit for the Go submodule (for example release-branch.go1.19)"
-    exit 1
+    GIT_REF=$(go run ${SCRIPT_DIR}/versions.go ${CONFIG_DIR}/versions.json github.com/golang/go)
+    if [ -z "${GIT_REF}" ]; then
+      echo "You must supply a branch, tag, or commit for the Go submodule (for example release-branch.go1.19)"
+      exit 1
+    fi
 fi
 
 git submodule add --force https://github.com/golang/go.git
@@ -14,5 +19,13 @@ git submodule update
 
 pushd go
 git checkout ${GIT_REF}
+
+# If we're on a branch, the cached tree might be out of sync,
+# so we should hard reset against origin.
+if [[ "$(git branch --show-current | wc -l)" == "1" ]]; then
+  git fetch
+  git reset origin/${GIT_REF} --hard
+fi
+
 popd
 

--- a/scripts/versions.go
+++ b/scripts/versions.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	// Script takes two arguments, the path to version.json,
+	// and the name of the repository.
+	if len(os.Args) < 3 {
+		log.Fatal("Error: requires exactly two arguments")
+	}
+	versionFile := os.Args[1]
+	repository := os.Args[2]
+
+	// Read the mapping of repositories to git refs.
+	content, err := ioutil.ReadFile(versionFile)
+	if err != nil {
+		log.Fatal("Could not open file: ", err)
+	}
+	var gitRefs map[string]string
+	err = json.Unmarshal(content, &gitRefs)
+	if err != nil {
+		log.Fatal("Could not unmarshal json: ", err)
+	}
+
+	// Print the result.
+	if gitRef, ok := gitRefs[repository]; ok {
+		fmt.Printf("%s\n", gitRef)
+	} else {
+		log.Fatalf("Invalid repository: %s", gitRef)
+	}
+}


### PR DESCRIPTION
Currently the scripts target the latest commit on a given branch. This is because the original intent was to set up a source branch once and then continually rebase upstream Go on top of it.  However, this is not the way the workflow has played out so far.  For Go 1.19+, we're currently distributing as scripts and patches that generate a golang-fips tree on top of an upstream Go ref.

This commit introduces a `versions.json` file with a mapping between repo versions and git refs for golang/go, golang-fips/go, and golang-fips/openssl-fips.  The setup scripts now read from `versions.json` when selecting the default git refs, allowing us to standardize dependencies to known working versions where a given commit of golang-fips/go will behave consistently.  A side effect is that the argument to `scripts/setup-initial-patch.sh` becomes optional.

For now, I've set the default refs to the main/master branches because this PR is against the main branch of golang-fips/go.  The idea is that the main branch will keep rolling dependencies, whereas we can hard-code stable commits/tags in the stable branches like go1.19-fips-release.