### PR TITLE
Add full-generate-repo script

### DIFF
--- a/scripts/full-initialize-repo.sh
+++ b/scripts/full-initialize-repo.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script generates and applies FIPS
+# patches to a Go tree.
+
+SCRIPT_DIR=$(readlink -f $(dirname $0))
+GO_DIR=${SCRIPT_DIR}/../go
+
+if [[ -d "${GO_DIR}" ]]; then
+  1>&2 echo "Existing go tree detected.  Aborting..."
+  exit 1
+fi
+
+${SCRIPT_DIR}/setup-initial-patch.sh $@
+
+set -ex
+pushd ${GO_DIR}
+for patch in $(ls ../patches); do
+  git apply ../patches/${patch}
+  git add -A
+  git commit -am ${patch}
+done
+popd


### PR DESCRIPTION
Most of the time when generating the FIPS patches, I also want to apply them back to the Go tree.  This commit adds a new script which applies the patches back to the tree after running setup-initial-patch.sh.