### PR TITLE
Add Crypto TestConfig and fix TLSv1.3 Crashes

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
 	"github.com/golang-fips/go":           "go1.19-fips-release",
-	"github.com/golang-fips/openssl-fips": "5dbcdfb69806f37da504402830fd0451c421d0dc",
+	"github.com/golang-fips/openssl-fips": "41938ace180b2426236eca4cfdef58d415cd70a1",
 	"github.com/golang/go":                "go1.19.4"
 }

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -125,6 +125,78 @@ index 0000000000..d12ba2f441
 +	testHashSignAndHashVerify(t, elliptic.P384(), "p384")
 +	testHashSignAndHashVerify(t, elliptic.P521(), "p521")
 +}
+diff --git a/src/crypto/ecdsa/ecdsa_test.go b/src/crypto/ecdsa/ecdsa_test.go
+index 77a8134316..b66b9a570c 100644
+--- a/src/crypto/ecdsa/ecdsa_test.go
++++ b/src/crypto/ecdsa/ecdsa_test.go
+@@ -12,6 +12,7 @@ import (
+ 	"crypto/sha1"
+ 	"crypto/sha256"
+ 	"crypto/sha512"
++	"crypto/internal/backend/boringtest"
+ 	"encoding/hex"
+ 	"hash"
+ 	"io"
+@@ -27,12 +28,17 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+ 		curve elliptic.Curve
+ 	}{
+ 		{"P256", elliptic.P256()},
+-		{"P224", elliptic.P224()},
+ 		{"P384", elliptic.P384()},
+ 		{"P521", elliptic.P521()},
+ 	}
+ 	if testing.Short() {
+ 		tests = tests[:1]
++	} else if boringtest.Supports(t, "CurveP224") {
++		p224 := struct {
++			name  string
++			curve elliptic.Curve
++		}{"P224", elliptic.P224()}
++		tests = append(tests, p224)
+ 	}
+ 	for _, test := range tests {
+ 		curve := test.curve
+@@ -223,7 +229,11 @@ func TestVectors(t *testing.T) {
+ 
+ 			switch curve {
+ 			case "P-224":
+-				pub.Curve = elliptic.P224()
++				if boringtest.Supports(t, "CurveP224") {
++					pub.Curve = elliptic.P224()
++				} else {
++					pub.Curve = nil
++				}
+ 			case "P-256":
+ 				pub.Curve = elliptic.P256()
+ 			case "P-384":
+diff --git a/src/crypto/ecdsa/equal_test.go b/src/crypto/ecdsa/equal_test.go
+index 53ac8504c2..71aeac6213 100644
+--- a/src/crypto/ecdsa/equal_test.go
++++ b/src/crypto/ecdsa/equal_test.go
+@@ -10,6 +10,7 @@ import (
+ 	"crypto/elliptic"
+ 	"crypto/rand"
+ 	"crypto/x509"
++	"crypto/internal/backend/boringtest"
+ 	"testing"
+ )
+ 
+@@ -65,11 +66,13 @@ func testEqual(t *testing.T, c elliptic.Curve) {
+ }
+ 
+ func TestEqual(t *testing.T) {
+-	t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
++	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })
+ 	if testing.Short() {
+ 		return
+ 	}
+-	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })
++	if boringtest.Supports(t, "CurveP224") {
++		t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
++	}
+ 	t.Run("P384", func(t *testing.T) { testEqual(t, elliptic.P384()) })
+ 	t.Run("P521", func(t *testing.T) { testEqual(t, elliptic.P521()) })
+ }
 diff --git a/src/crypto/ed25519/ed25519_test.go b/src/crypto/ed25519/ed25519_test.go
 index 7c5181788f..102c4e5355 100644
 --- a/src/crypto/ed25519/ed25519_test.go
@@ -193,15 +265,64 @@ index 0000000000..c0800df578
 +	x := (*(*[]big.Word)(unsafe.Pointer(&b)))[:len(b)]
 +	return new(big.Int).SetBits(x)
 +}
+diff --git a/src/crypto/internal/backend/boringtest/config.go b/src/crypto/internal/backend/boringtest/config.go
+new file mode 100644
+index 0000000000..976aa85cea
+--- /dev/null
++++ b/src/crypto/internal/backend/boringtest/config.go
+@@ -0,0 +1,43 @@
++/* Test configuration package for OpenSSL FIPS
++
++The FIPS mode behavior of OpenSSL varies between versions and distributions
++depending which version of the FIPS standard the library targets. Because
++the Go crypto tests can not reliably account for these behavioral differences, 
++building golang-fips on a new distribution often results in test failures due to
++variations in things like supported crypto algorithms and key sizes.
++
++The goal of this package is to implement a compile-time defined configuration
++for the behavior of OpenSSL, which is more easily configurable to run in different
++environments.  The compile-time schema was chosen as the preferred method, because
++we don't want elements of the run-time environment to impact the result of the tests
++(for example, changes to the environment or config files).
++*/
++
++package boringtest
++
++import (
++	"testing"
++)
++
++var TestConfig map[string]bool
++
++func init() {
++	TestConfig = map[string]bool{
++		"PKCSv1.5": false,
++		"SHA1": false,
++		// really this is anything < 2048
++		"RSA1024": false,
++		"RSA4096LeafCert": true,
++		"RSA1024LeafCert": false,
++		"TLS13": true,
++		"CurveP224": true,
++	}
++}
++
++func Supports(t *testing.T, key string) bool {
++	result, ok := TestConfig[key]
++	if !ok {
++		panic("key not found in boringtest.TestConfig: " + key)
++	}
++	return result
++}
 diff --git a/src/crypto/internal/backend/dummy.s b/src/crypto/internal/backend/dummy.s
 new file mode 100644
 index 0000000000..e69de29bb2
 diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
 new file mode 100644
-index 0000000000..482ed6f470
+index 0000000000..e9d2df4521
 --- /dev/null
 +++ b/src/crypto/internal/backend/nobackend.go
-@@ -0,0 +1,155 @@
+@@ -0,0 +1,158 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -351,6 +472,9 @@ index 0000000000..482ed6f470
 +func ExpandHKDF(h func() hash.Hash, pseudorandomKey, info []byte) (io.Reader, error) {
 +	panic("boringcrypto: not available")
 +}
++func SupportsHKDF() bool {
++	panic("boringcrypto: not available")
++}
 +func HashVerifyECDSA(pub *PublicKeyECDSA, msg []byte, r, s *big.Int, h crypto.Hash) bool {
 +	panic("boringcrypto: not available")
 +}
@@ -359,10 +483,10 @@ index 0000000000..482ed6f470
 +}
 diff --git a/src/crypto/internal/backend/openssl.go b/src/crypto/internal/backend/openssl.go
 new file mode 100644
-index 0000000000..4040c77bc1
+index 0000000000..2721d06078
 --- /dev/null
 +++ b/src/crypto/internal/backend/openssl.go
-@@ -0,0 +1,105 @@
+@@ -0,0 +1,106 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -468,63 +592,65 @@ index 0000000000..4040c77bc1
 +
 +var ExtractHKDF = openssl.ExtractHKDF
 +var ExpandHKDF = openssl.ExpandHKDF
++var SupportsHKDF = openssl.SupportsHKDF
 diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
-index 69c509a771..05eac35d88 100644
+index 69c509a771..4383108679 100644
 --- a/src/crypto/rsa/pkcs1v15_test.go
 +++ b/src/crypto/rsa/pkcs1v15_test.go
-@@ -7,6 +7,7 @@ package rsa
+@@ -7,6 +7,8 @@ package rsa
  import (
  	"bytes"
  	"crypto"
 +	"crypto/internal/boring"
++	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/sha1"
  	"crypto/sha256"
-@@ -52,6 +53,10 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
+@@ -52,6 +54,10 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
  
  func TestDecryptPKCS1v15(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
  	decryptionFuncs := []func([]byte) ([]byte, error){
  		func(ciphertext []byte) (plaintext []byte, err error) {
  			return DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
-@@ -76,6 +81,10 @@ func TestDecryptPKCS1v15(t *testing.T) {
+@@ -76,6 +82,10 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
  
  func TestEncryptPKCS1v15(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
  	random := rand.Reader
  	k := (rsaPrivateKey.N.BitLen() + 7) / 8
  
-@@ -137,6 +146,10 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
+@@ -137,6 +147,10 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
  
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
  	for i, test := range decryptPKCS1v15SessionKeyTests {
  		key := []byte("FAIL")
  		err := DecryptPKCS1v15SessionKey(nil, rsaPrivateKey, decodeBase64(test.in), key)
-@@ -151,6 +164,10 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
+@@ -151,6 +165,10 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
  
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
  	for i, test := range decryptPKCS1v15SessionKeyTests {
  		plaintext, err := rsaPrivateKey.Decrypt(rand.Reader, decodeBase64(test.in), &PKCS1v15DecryptOptions{SessionKeyLen: 4})
  		if err != nil {
-@@ -190,7 +207,7 @@ type signPKCS1v15Test struct {
+@@ -190,7 +208,7 @@ type signPKCS1v15Test struct {
  //
  //	`openssl rsautl -verify -inkey pk -in signature | hexdump -C`
  var signPKCS1v15Tests = []signPKCS1v15Test{
@@ -533,7 +659,7 @@ index 69c509a771..05eac35d88 100644
  }
  
  func TestSignPKCS1v15(t *testing.T) {
-@@ -199,7 +216,7 @@ func TestSignPKCS1v15(t *testing.T) {
+@@ -199,7 +217,7 @@ func TestSignPKCS1v15(t *testing.T) {
  		h.Write([]byte(test.in))
  		digest := h.Sum(nil)
  
@@ -542,7 +668,7 @@ index 69c509a771..05eac35d88 100644
  		if err != nil {
  			t.Errorf("#%d %s", i, err)
  		}
-@@ -219,7 +236,7 @@ func TestVerifyPKCS1v15(t *testing.T) {
+@@ -219,7 +237,7 @@ func TestVerifyPKCS1v15(t *testing.T) {
  
  		sig, _ := hex.DecodeString(test.out)
  
@@ -551,7 +677,7 @@ index 69c509a771..05eac35d88 100644
  		if err != nil {
  			t.Errorf("#%d %s", i, err)
  		}
-@@ -242,21 +259,25 @@ func TestUnpaddedSignature(t *testing.T) {
+@@ -242,21 +260,25 @@ func TestUnpaddedSignature(t *testing.T) {
  	//
  	// Where "key" contains the RSA private key given at the bottom of this
  	// file.
@@ -573,14 +699,14 @@ index 69c509a771..05eac35d88 100644
  }
  
  func TestShortSessionKey(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
  	// This tests that attempting to decrypt a session key where the
  	// ciphertext is too small doesn't run outside the array bounds.
  	ciphertext, err := EncryptPKCS1v15(rand.Reader, &rsaPrivateKey.PublicKey, []byte{1})
-@@ -299,6 +320,51 @@ var rsaPrivateKey = &PrivateKey{
+@@ -299,6 +321,51 @@ var rsaPrivateKey = &PrivateKey{
  	},
  }
  
@@ -633,28 +759,29 @@ index 69c509a771..05eac35d88 100644
  	pub := &PublicKey{
  		E: 65537,
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index 51f9760187..93bbc26bd0 100644
+index 51f9760187..ad82d4456f 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
-@@ -9,6 +9,7 @@ import (
+@@ -9,6 +9,8 @@ import (
  	"bytes"
  	"compress/bzip2"
  	"crypto"
 +	"crypto/internal/boring"
++	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/sha1"
  	"crypto/sha256"
-@@ -76,6 +77,9 @@ func TestEMSAPSS(t *testing.T) {
+@@ -76,6 +78,9 @@ func TestEMSAPSS(t *testing.T) {
  // TestPSSGolden tests all the test vectors in pss-vect.txt from
  // ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1-vec.zip
  func TestPSSGolden(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: SHA-1 not allowed")
 +	}
  	inFile, err := os.Open("testdata/pss-vect.txt.bz2")
  	if err != nil {
  		t.Fatalf("Failed to open input file: %s", err)
-@@ -167,6 +171,10 @@ func TestPSSGolden(t *testing.T) {
+@@ -167,6 +172,10 @@ func TestPSSGolden(t *testing.T) {
  // TestPSSOpenSSL ensures that we can verify a PSS signature from OpenSSL with
  // the default options. OpenSSL sets the salt length to be maximal.
  func TestPSSOpenSSL(t *testing.T) {
@@ -665,7 +792,7 @@ index 51f9760187..93bbc26bd0 100644
  	hash := crypto.SHA256
  	h := hash.New()
  	h.Write([]byte("testing"))
-@@ -194,10 +202,15 @@ func TestPSSNilOpts(t *testing.T) {
+@@ -194,10 +203,15 @@ func TestPSSNilOpts(t *testing.T) {
  	h.Write([]byte("testing"))
  	hashed := h.Sum(nil)
  
@@ -674,14 +801,14 @@ index 51f9760187..93bbc26bd0 100644
  }
  
  func TestPSSSigning(t *testing.T) {
-+	if boring.Enabled {
++	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: too short key")
 +	}
 +
  	var saltLengthCombinations = []struct {
  		signSaltLength, verifySaltLength int
  		good                             bool
-@@ -233,7 +246,7 @@ func TestPSSSigning(t *testing.T) {
+@@ -233,7 +247,7 @@ func TestPSSSigning(t *testing.T) {
  }
  
  func TestSignWithPSSSaltLengthAuto(t *testing.T) {
@@ -691,10 +818,18 @@ index 51f9760187..93bbc26bd0 100644
  		t.Fatal(err)
  	}
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 766d9a954f..dc502cae8f 100644
+index 766d9a954f..7d24a08882 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
-@@ -26,6 +26,10 @@ func TestKeyGeneration(t *testing.T) {
+@@ -16,6 +16,7 @@ import (
+ )
+ 
+ import "crypto/internal/boring"
++import "crypto/internal/backend/boringtest"
+ 
+ func TestKeyGeneration(t *testing.T) {
+ 	for _, size := range []int{128, 1024, 2048, 3072} {
+@@ -26,6 +27,10 @@ func TestKeyGeneration(t *testing.T) {
  		if bits := priv.N.BitLen(); bits != size {
  			t.Errorf("key too short (%d vs %d)", bits, size)
  		}
@@ -705,7 +840,7 @@ index 766d9a954f..dc502cae8f 100644
  		testKeyBasics(t, priv)
  		if testing.Short() {
  			break
-@@ -115,16 +119,23 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
+@@ -115,16 +120,23 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  	}
  
  	if boring.Enabled {
@@ -734,33 +869,33 @@ index 766d9a954f..dc502cae8f 100644
  			return
  		}
  		if !bytes.Equal(dec, msg) {
-@@ -253,6 +264,10 @@ func TestEncryptOAEP(t *testing.T) {
+@@ -253,6 +265,10 @@ func TestEncryptOAEP(t *testing.T) {
  	n := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
-+		if boring.Enabled && n.BitLen() < 2048 {
++		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
 +			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +			continue
 +		}
  		public := PublicKey{N: n, E: test.e}
  
  		for j, message := range test.msgs {
-@@ -276,6 +291,10 @@ func TestDecryptOAEP(t *testing.T) {
+@@ -276,6 +292,10 @@ func TestDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
-+		if boring.Enabled && n.BitLen() < 2048 {
++		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
 +			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +			continue
 +		}
  		d.SetString(test.d, 16)
  		private := new(PrivateKey)
  		private.PublicKey = PublicKey{N: n, E: test.e}
-@@ -309,6 +328,10 @@ func TestEncryptDecryptOAEP(t *testing.T) {
+@@ -309,6 +329,10 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
-+		if boring.Enabled && n.BitLen() < 2048 {
++		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
 +			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +			continue
 +		}
@@ -768,7 +903,7 @@ index 766d9a954f..dc502cae8f 100644
  		priv := new(PrivateKey)
  		priv.PublicKey = PublicKey{N: n, E: test.e}
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 1827f76458..4c5c3527a4 100644
+index 1827f76458..140b1a3dd8 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -8,8 +8,15 @@ package tls
@@ -787,7 +922,7 @@ index 1827f76458..4c5c3527a4 100644
  // needFIPS returns fipstls.Required(); it avoids a new import in common.go.
  func needFIPS() bool {
  	return fipstls.Required()
-@@ -17,14 +24,14 @@ func needFIPS() bool {
+@@ -17,14 +24,18 @@ func needFIPS() bool {
  
  // fipsMinVersion replaces c.minVersion in FIPS-only mode.
  func fipsMinVersion(c *Config) uint16 {
@@ -801,37 +936,57 @@ index 1827f76458..4c5c3527a4 100644
 -	// FIPS requires TLS 1.2.
 -	return VersionTLS12
 +	// FIPS requires TLS 1.2 or later.
-+	return VersionTLS13
++	if boring.SupportsHKDF() {
++		return VersionTLS13
++	}  else {
++		return VersionTLS12
++	}
  }
  
  // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index 59d4d2b272..b572a59303 100644
+index 59d4d2b272..2ae3814364 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
-@@ -9,6 +9,7 @@ package tls
+@@ -9,6 +9,8 @@ package tls
  import (
  	"crypto/ecdsa"
  	"crypto/elliptic"
 +	"crypto/internal/boring"
++	"crypto/internal/backend/boringtest"
  	"crypto/internal/boring/fipstls"
  	"crypto/rand"
  	"crypto/rsa"
-@@ -52,11 +53,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+@@ -44,7 +46,11 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test("VersionTLS10", VersionTLS10, "")
+ 	test("VersionTLS11", VersionTLS11, "")
+ 	test("VersionTLS12", VersionTLS12, "")
+-	test("VersionTLS13", VersionTLS13, "")
++	if boring.Enabled && !boring.SupportsHKDF() {
++		test("VersionTLS13", VersionTLS13, "client offered only unsupported versions")
++	} else {
++		test("VersionTLS13", VersionTLS13, "")
++	}
+ 
+ 	fipstls.Force()
+ 	defer fipstls.Abandon()
+@@ -52,11 +58,13 @@ func TestBoringServerProtocolVersion(t *testing.T) {
  	test("VersionTLS10", VersionTLS10, "client offered only unsupported versions")
  	test("VersionTLS11", VersionTLS11, "client offered only unsupported versions")
  	test("VersionTLS12", VersionTLS12, "")
 -	test("VersionTLS13", VersionTLS13, "client offered only unsupported versions")
-+	test("VersionTLS13", VersionTLS13, "")
++	if boring.SupportsHKDF() {
++		test("VersionTLS13", VersionTLS13, "")
++	}
  }
  
  func isBoringVersion(v uint16) bool {
 -	return v == VersionTLS12
-+	return v == VersionTLS12 || v == VersionTLS13
++	return v == VersionTLS12 || (boring.SupportsHKDF() && v == VersionTLS13)
  }
  
  func isBoringCipherSuite(id uint16) bool {
-@@ -66,7 +67,9 @@ func isBoringCipherSuite(id uint16) bool {
+@@ -66,7 +74,9 @@ func isBoringCipherSuite(id uint16) bool {
  		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
  		TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
  		TLS_RSA_WITH_AES_128_GCM_SHA256,
@@ -842,8 +997,20 @@ index 59d4d2b272..b572a59303 100644
  		return true
  	}
  	return false
-@@ -318,12 +321,12 @@ func TestBoringCertAlgs(t *testing.T) {
- 	M2_R1 := boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
+@@ -315,15 +325,31 @@ func TestBoringCertAlgs(t *testing.T) {
+ 	R2 := boringCert(t, "R2", boringRSAKey(t, 512), nil, boringCertCA)
+ 
+ 	M1_R1 := boringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
+-	M2_R1 := boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
++
++	// If OpenSSL supports P224, use the default upstream behavior,
++	// otherwise test with P384
++	var M2_R1 *boringCertificate
++	if boringtest.Supports(t, "CurveP224") {
++		M2_R1 = boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
++	} else {
++		M2_R1 = boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
++	}
  
  	I_R1 := boringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
 -	I_R2 := boringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
@@ -853,11 +1020,19 @@ index 59d4d2b272..b572a59303 100644
  
  	L1_I := boringCert(t, "L1_I", boringECDSAKey(t, elliptic.P384()), I_R1, boringCertLeaf|boringCertFIPSOK)
 -	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf)
-+	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf|boringCertNotBoring)
++
++
++	// Older versions of OpenSSL allow 1024 bit leaf certs
++	var L2_I *boringCertificate
++	if boringtest.Supports(t, "RSA1024LeafCert") {
++		L2_I = boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf)
++	} else {
++		L2_I = boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf|boringCertNotBoring)
++	}
  
  	// client verifying server cert
  	testServerCert := func(t *testing.T, desc string, pool *x509.CertPool, key interface{}, list [][]byte, ok bool) {
-@@ -362,6 +365,11 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -362,6 +388,11 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig := testConfig.Clone()
  		serverConfig.ClientCAs = pool
  		serverConfig.ClientAuth = RequireAndVerifyClientCert
@@ -869,7 +1044,7 @@ index 59d4d2b272..b572a59303 100644
  
  		_, serverErr := boringHandshake(t, clientConfig, serverConfig)
  
-@@ -384,8 +392,8 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -384,8 +415,8 @@ func TestBoringCertAlgs(t *testing.T) {
  	// exhaustive test with computed answers.
  	r1pool := x509.NewCertPool()
  	r1pool.AddCert(R1.cert)
@@ -880,7 +1055,7 @@ index 59d4d2b272..b572a59303 100644
  	fipstls.Force()
  	testServerCert(t, "basic (fips)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
  	testClientCert(t, "basic (fips, client cert)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
-@@ -406,7 +414,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -406,7 +437,7 @@ func TestBoringCertAlgs(t *testing.T) {
  			leaf = L2_I
  		}
  		for i := 0; i < 64; i++ {
@@ -889,7 +1064,7 @@ index 59d4d2b272..b572a59303 100644
  			reachableFIPS := map[string]bool{leaf.parentOrg: leaf.fipsOK}
  			list := [][]byte{leaf.der}
  			listName := leaf.name
-@@ -414,7 +422,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -414,7 +445,7 @@ func TestBoringCertAlgs(t *testing.T) {
  				if cond != 0 {
  					list = append(list, c.der)
  					listName += "," + c.name
@@ -898,7 +1073,7 @@ index 59d4d2b272..b572a59303 100644
  						reachable[c.parentOrg] = true
  					}
  					if reachableFIPS[c.org] && c.fipsOK {
-@@ -438,7 +446,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -438,7 +469,7 @@ func TestBoringCertAlgs(t *testing.T) {
  					if cond != 0 {
  						rootName += "," + c.name
  						pool.AddCert(c.cert)
@@ -907,7 +1082,7 @@ index 59d4d2b272..b572a59303 100644
  							shouldVerify = true
  						}
  						if reachableFIPS[c.org] && c.fipsOK {
-@@ -464,6 +472,7 @@ const (
+@@ -464,6 +495,7 @@ const (
  	boringCertCA = iota
  	boringCertLeaf
  	boringCertFIPSOK = 0x80
@@ -915,7 +1090,7 @@ index 59d4d2b272..b572a59303 100644
  )
  
  func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
-@@ -490,6 +499,7 @@ type boringCertificate struct {
+@@ -490,6 +522,7 @@ type boringCertificate struct {
  	cert      *x509.Certificate
  	key       interface{}
  	fipsOK    bool
@@ -923,7 +1098,7 @@ index 59d4d2b272..b572a59303 100644
  }
  
  func boringCert(t *testing.T, name string, key interface{}, parent *boringCertificate, mode int) *boringCertificate {
-@@ -511,7 +521,7 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
+@@ -511,7 +544,7 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
  		BasicConstraintsValid: true,
  	}
@@ -932,7 +1107,7 @@ index 59d4d2b272..b572a59303 100644
  		tmpl.DNSNames = []string{"example.com"}
  	} else {
  		tmpl.IsCA = true
-@@ -548,7 +558,8 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
+@@ -548,7 +581,8 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  	}
  
  	fipsOK := mode&boringCertFIPSOK != 0
@@ -958,6 +1133,28 @@ index 9a1fa3104b..f7c64dba42 100644
  var (
  	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
  	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+diff --git a/src/crypto/tls/common.go b/src/crypto/tls/common.go
+index 1861efce66..3b3e166abc 100644
+--- a/src/crypto/tls/common.go
++++ b/src/crypto/tls/common.go
+@@ -12,6 +12,7 @@ import (
+ 	"crypto/ecdsa"
+ 	"crypto/ed25519"
+ 	"crypto/elliptic"
++	"crypto/internal/boring"
+ 	"crypto/rand"
+ 	"crypto/rsa"
+ 	"crypto/sha512"
+@@ -984,6 +985,9 @@ const roleServer = false
+ func (c *Config) supportedVersions(isClient bool) []uint16 {
+ 	versions := make([]uint16, 0, len(supportedVersions))
+ 	for _, v := range supportedVersions {
++		if boring.Enabled && !boring.SupportsHKDF() && v > VersionTLS12 {
++			continue
++		}
+ 		if needFIPS() && (v < fipsMinVersion(c) || v > fipsMaxVersion(c)) {
+ 			continue
+ 		}
 diff --git a/src/crypto/tls/handshake_client.go b/src/crypto/tls/handshake_client.go
 index e61e3eb540..7031ab8706 100644
 --- a/src/crypto/tls/handshake_client.go
@@ -1129,19 +1326,49 @@ index 314016979a..323d683788 100644
  }
  
  type x25519Parameters struct {
+diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
+index 90fe2a7227..c742e4992f 100644
+--- a/src/crypto/x509/boring_test.go
++++ b/src/crypto/x509/boring_test.go
+@@ -10,6 +10,7 @@ import (
+ 	"crypto/ecdsa"
+ 	"crypto/elliptic"
+ 	"crypto/internal/boring/fipstls"
++	"crypto/internal/backend/boringtest"
+ 	"crypto/rand"
+ 	"crypto/rsa"
+ 	"crypto/x509/pkix"
+@@ -58,7 +59,15 @@ func TestBoringAllowCert(t *testing.T) {
+ 	R3 := testBoringCert(t, "R3", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
+ 
+ 	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
+-	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
++
++	var M2_R1 *boringCertificate
++	// If OpenSSL supports P224, use the default upstream behavior,
++	// otherwise test with P384
++	if boringtest.Supports(t, "CurveP224") {
++		M2_R1 = testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
++	} else {
++		M2_R1 = testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
++	}
+ 
+ 	I_R1 := testBoringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
+ 	testBoringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
-index b1cdabba28..f2d7a2bd6e 100644
+index 167ddb7fd0..e7c7ee63c8 100644
 --- a/src/crypto/x509/x509_test.go
 +++ b/src/crypto/x509/x509_test.go
-@@ -11,6 +11,7 @@ import (
+@@ -11,6 +11,8 @@ import (
  	"crypto/ecdsa"
  	"crypto/ed25519"
  	"crypto/elliptic"
 +	"crypto/internal/boring"
++	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/rsa"
  	_ "crypto/sha256"
-@@ -117,32 +118,54 @@ func TestParsePKIXPublicKey(t *testing.T) {
+@@ -117,32 +119,54 @@ func TestParsePKIXPublicKey(t *testing.T) {
  	})
  }
  
@@ -1216,7 +1443,7 @@ index b1cdabba28..f2d7a2bd6e 100644
  -----END RSA TESTING KEY-----
  `)
  
-@@ -195,13 +218,13 @@ func bigFromHexString(s string) *big.Int {
+@@ -195,13 +219,13 @@ func bigFromHexString(s string) *big.Int {
  
  var rsaPrivateKey = &rsa.PrivateKey{
  	PublicKey: rsa.PublicKey{
@@ -1234,7 +1461,7 @@ index b1cdabba28..f2d7a2bd6e 100644
  	},
  }
  
-@@ -614,6 +637,13 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
+@@ -614,6 +638,13 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
  
  	for _, test := range tests {
@@ -1248,11 +1475,33 @@ index b1cdabba28..f2d7a2bd6e 100644
  		commonName := "test.example.com"
  		template := Certificate{
  			SerialNumber: big.NewInt(1),
+@@ -3544,11 +3575,19 @@ func TestParseRevocationList(t *testing.T) {
+ }
+ 
+ func TestRevocationListCheckSignatureFrom(t *testing.T) {
+-	goodKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
++	var testCurve elliptic.Curve
++	// If OpenSSL supports P224, use the default upstream behavior,
++	// otherwise test with P384
++	if boringtest.Supports(t, "CurveP224") {
++		testCurve = elliptic.P224()
++	} else {
++		testCurve = elliptic.P384()
++	}
++	goodKey, err := ecdsa.GenerateKey(testCurve, rand.Reader)
+ 	if err != nil {
+ 		t.Fatalf("failed to generate test key: %s", err)
+ 	}
+-	badKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
++	badKey, err := ecdsa.GenerateKey(testCurve, rand.Reader)
+ 	if err != nil {
+ 		t.Fatalf("failed to generate test key: %s", err)
+ 	}
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
-index 141fdb9fbd..d8e81d921d 100644
+index 73df030638..1de20b996e 100644
 --- a/src/go/build/deps_test.go
 +++ b/src/go/build/deps_test.go
-@@ -414,19 +414,23 @@ var depsRules = `
+@@ -415,19 +415,23 @@ var depsRules = `
  	< crypto/internal/edwards25519
  	< crypto/cipher;
  
@@ -1278,7 +1527,7 @@ index 141fdb9fbd..d8e81d921d 100644
  	< crypto/internal/randutil
  	< crypto/rand
  	< crypto/ed25519
-@@ -601,6 +605,7 @@ func listStdPkgs(goroot string) ([]string, error) {
+@@ -602,6 +606,7 @@ func listStdPkgs(goroot string) ([]string, error) {
  }
  
  func TestDependencies(t *testing.T) {
@@ -1286,7 +1535,7 @@ index 141fdb9fbd..d8e81d921d 100644
  	if !testenv.HasSrc() {
  		// Tests run in a limited file system and we do not
  		// provide access to every source file.
-@@ -644,7 +649,7 @@ var buildIgnore = []byte("\n//go:build ignore")
+@@ -645,7 +650,7 @@ var buildIgnore = []byte("\n//go:build ignore")
  
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
@@ -1295,7 +1544,7 @@ index 141fdb9fbd..d8e81d921d 100644
  		vpkg = "vendor/" + pkg
  	}
  	dir := filepath.Join(Default.GOROOT, "src", vpkg)
-@@ -654,7 +659,7 @@ func findImports(pkg string) ([]string, error) {
+@@ -655,7 +660,7 @@ func findImports(pkg string) ([]string, error) {
  	}
  	var imports []string
  	var haveImport = map[string]bool{}

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -126,18 +126,19 @@ index 0000000000..d12ba2f441
 +	testHashSignAndHashVerify(t, elliptic.P521(), "p521")
 +}
 diff --git a/src/crypto/ecdsa/ecdsa_test.go b/src/crypto/ecdsa/ecdsa_test.go
-index 77a8134316..b66b9a570c 100644
+index 77a8134316..db56cdd26e 100644
 --- a/src/crypto/ecdsa/ecdsa_test.go
 +++ b/src/crypto/ecdsa/ecdsa_test.go
-@@ -12,6 +12,7 @@ import (
+@@ -12,6 +12,8 @@ import (
  	"crypto/sha1"
  	"crypto/sha256"
  	"crypto/sha512"
++	"crypto/internal/boring"
 +	"crypto/internal/backend/boringtest"
  	"encoding/hex"
  	"hash"
  	"io"
-@@ -27,12 +28,17 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+@@ -27,12 +29,17 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
  		curve elliptic.Curve
  	}{
  		{"P256", elliptic.P256()},
@@ -147,7 +148,7 @@ index 77a8134316..b66b9a570c 100644
  	}
  	if testing.Short() {
  		tests = tests[:1]
-+	} else if boringtest.Supports(t, "CurveP224") {
++	} else if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
 +		p224 := struct {
 +			name  string
 +			curve elliptic.Curve
@@ -156,12 +157,12 @@ index 77a8134316..b66b9a570c 100644
  	}
  	for _, test := range tests {
  		curve := test.curve
-@@ -223,7 +229,11 @@ func TestVectors(t *testing.T) {
+@@ -223,7 +230,11 @@ func TestVectors(t *testing.T) {
  
  			switch curve {
  			case "P-224":
 -				pub.Curve = elliptic.P224()
-+				if boringtest.Supports(t, "CurveP224") {
++				if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
 +					pub.Curve = elliptic.P224()
 +				} else {
 +					pub.Curve = nil
@@ -170,18 +171,19 @@ index 77a8134316..b66b9a570c 100644
  				pub.Curve = elliptic.P256()
  			case "P-384":
 diff --git a/src/crypto/ecdsa/equal_test.go b/src/crypto/ecdsa/equal_test.go
-index 53ac8504c2..71aeac6213 100644
+index 53ac8504c2..4371e31b1a 100644
 --- a/src/crypto/ecdsa/equal_test.go
 +++ b/src/crypto/ecdsa/equal_test.go
-@@ -10,6 +10,7 @@ import (
+@@ -10,6 +10,8 @@ import (
  	"crypto/elliptic"
  	"crypto/rand"
  	"crypto/x509"
++	"crypto/internal/boring"
 +	"crypto/internal/backend/boringtest"
  	"testing"
  )
  
-@@ -65,11 +66,13 @@ func testEqual(t *testing.T, c elliptic.Curve) {
+@@ -65,11 +67,13 @@ func testEqual(t *testing.T, c elliptic.Curve) {
  }
  
  func TestEqual(t *testing.T) {
@@ -191,7 +193,7 @@ index 53ac8504c2..71aeac6213 100644
  		return
  	}
 -	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })
-+	if boringtest.Supports(t, "CurveP224") {
++	if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
 +		t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
 +	}
  	t.Run("P384", func(t *testing.T) { testEqual(t, elliptic.P384()) })
@@ -267,7 +269,7 @@ index 0000000000..c0800df578
 +}
 diff --git a/src/crypto/internal/backend/boringtest/config.go b/src/crypto/internal/backend/boringtest/config.go
 new file mode 100644
-index 0000000000..976aa85cea
+index 0000000000..521f374ebd
 --- /dev/null
 +++ b/src/crypto/internal/backend/boringtest/config.go
 @@ -0,0 +1,43 @@
@@ -292,10 +294,10 @@ index 0000000000..976aa85cea
 +	"testing"
 +)
 +
-+var TestConfig map[string]bool
++var testConfig map[string]bool
 +
 +func init() {
-+	TestConfig = map[string]bool{
++	testConfig = map[string]bool{
 +		"PKCSv1.5": false,
 +		"SHA1": false,
 +		// really this is anything < 2048
@@ -308,7 +310,7 @@ index 0000000000..976aa85cea
 +}
 +
 +func Supports(t *testing.T, key string) bool {
-+	result, ok := TestConfig[key]
++	result, ok := testConfig[key]
 +	if !ok {
 +		panic("key not found in boringtest.TestConfig: " + key)
 +	}
@@ -594,7 +596,7 @@ index 0000000000..2721d06078
 +var ExpandHKDF = openssl.ExpandHKDF
 +var SupportsHKDF = openssl.SupportsHKDF
 diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
-index 69c509a771..4383108679 100644
+index 69c509a771..c9c5ebcc04 100644
 --- a/src/crypto/rsa/pkcs1v15_test.go
 +++ b/src/crypto/rsa/pkcs1v15_test.go
 @@ -7,6 +7,8 @@ package rsa
@@ -610,7 +612,7 @@ index 69c509a771..4383108679 100644
  }
  
  func TestDecryptPKCS1v15(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
@@ -621,7 +623,7 @@ index 69c509a771..4383108679 100644
  }
  
  func TestEncryptPKCS1v15(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
@@ -632,7 +634,7 @@ index 69c509a771..4383108679 100644
  }
  
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
@@ -643,7 +645,7 @@ index 69c509a771..4383108679 100644
  }
  
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
@@ -699,7 +701,7 @@ index 69c509a771..4383108679 100644
  }
  
  func TestShortSessionKey(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
 +	}
 +
@@ -759,7 +761,7 @@ index 69c509a771..4383108679 100644
  	pub := &PublicKey{
  		E: 65537,
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index 51f9760187..ad82d4456f 100644
+index 51f9760187..eceb31aa71 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -9,6 +9,8 @@ import (
@@ -775,7 +777,7 @@ index 51f9760187..ad82d4456f 100644
  // TestPSSGolden tests all the test vectors in pss-vect.txt from
  // ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1-vec.zip
  func TestPSSGolden(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
++	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: SHA-1 not allowed")
 +	}
  	inFile, err := os.Open("testdata/pss-vect.txt.bz2")
@@ -801,7 +803,7 @@ index 51f9760187..ad82d4456f 100644
  }
  
  func TestPSSSigning(t *testing.T) {
-+	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
++	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: too short key")
 +	}
 +
@@ -1356,7 +1358,7 @@ index 90fe2a7227..c742e4992f 100644
  	I_R1 := testBoringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
  	testBoringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
-index 167ddb7fd0..e7c7ee63c8 100644
+index 167ddb7fd0..f5ce78166e 100644
 --- a/src/crypto/x509/x509_test.go
 +++ b/src/crypto/x509/x509_test.go
 @@ -11,6 +11,8 @@ import (
@@ -1483,7 +1485,7 @@ index 167ddb7fd0..e7c7ee63c8 100644
 +	var testCurve elliptic.Curve
 +	// If OpenSSL supports P224, use the default upstream behavior,
 +	// otherwise test with P384
-+	if boringtest.Supports(t, "CurveP224") {
++	if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
 +		testCurve = elliptic.P224()
 +	} else {
 +		testCurve = elliptic.P384()

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -277,7 +277,7 @@ index 0000000000..521f374ebd
 +
 +The FIPS mode behavior of OpenSSL varies between versions and distributions
 +depending which version of the FIPS standard the library targets. Because
-+the Go crypto tests can not reliably account for these behavioral differences, 
++the Go crypto tests can not reliably account for these behavioral differences,
 +building golang-fips on a new distribution often results in test failures due to
 +variations in things like supported crypto algorithms and key sizes.
 +

--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -1159,7 +1159,7 @@ index ab19229a6c..87b0ec98d9 100644
  		}
  		return nil
 diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
-index 05eac35d88..600d56b916 100644
+index 4383108679..7e01801f9e 100644
 --- a/src/crypto/rsa/pkcs1v15_test.go
 +++ b/src/crypto/rsa/pkcs1v15_test.go
 @@ -7,7 +7,7 @@ package rsa
@@ -1168,51 +1168,51 @@ index 05eac35d88..600d56b916 100644
  	"crypto"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/sha1"
- 	"crypto/sha256"
-@@ -53,7 +53,7 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
+@@ -54,7 +54,7 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
  
  func TestDecryptPKCS1v15(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
-@@ -81,7 +81,7 @@ func TestDecryptPKCS1v15(t *testing.T) {
+@@ -82,7 +82,7 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
  
  func TestEncryptPKCS1v15(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
-@@ -146,7 +146,7 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
+@@ -147,7 +147,7 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
  
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
-@@ -164,7 +164,7 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
+@@ -165,7 +165,7 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
  
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
-@@ -274,7 +274,7 @@ func TestUnpaddedSignature(t *testing.T) {
+@@ -275,7 +275,7 @@ func TestUnpaddedSignature(t *testing.T) {
  }
  
  func TestShortSessionKey(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1257,7 +1257,7 @@ index 29e79bd342..e7431e8062 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index 93bbc26bd0..d33299dd2c 100644
+index ad82d4456f..4ba0c23340 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -9,7 +9,7 @@ import (
@@ -1266,19 +1266,19 @@ index 93bbc26bd0..d33299dd2c 100644
  	"crypto"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/sha1"
- 	"crypto/sha256"
-@@ -77,7 +77,7 @@ func TestEMSAPSS(t *testing.T) {
+@@ -78,7 +78,7 @@ func TestEMSAPSS(t *testing.T) {
  // TestPSSGolden tests all the test vectors in pss-vect.txt from
  // ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1-vec.zip
  func TestPSSGolden(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
++	if boring.Enabled() && ! boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: SHA-1 not allowed")
  	}
  	inFile, err := os.Open("testdata/pss-vect.txt.bz2")
-@@ -171,7 +171,7 @@ func TestPSSGolden(t *testing.T) {
+@@ -172,7 +172,7 @@ func TestPSSGolden(t *testing.T) {
  // TestPSSOpenSSL ensures that we can verify a PSS signature from OpenSSL with
  // the default options. OpenSSL sets the salt length to be maximal.
  func TestPSSOpenSSL(t *testing.T) {
@@ -1287,12 +1287,12 @@ index 93bbc26bd0..d33299dd2c 100644
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
  
-@@ -207,7 +207,7 @@ func TestPSSNilOpts(t *testing.T) {
+@@ -208,7 +208,7 @@ func TestPSSNilOpts(t *testing.T) {
  }
  
  func TestPSSSigning(t *testing.T) {
--	if boring.Enabled {
-+	if boring.Enabled() {
+-	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
++	if boring.Enabled() && ! boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
  
@@ -1348,7 +1348,7 @@ index c941124fb2..7ea291c6f4 100644
  		if err != nil {
  			return nil, err
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index dc502cae8f..2f0752d1f5 100644
+index 7d24a08882..fa3f094330 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -15,7 +15,7 @@ import (
@@ -1357,10 +1357,10 @@ index dc502cae8f..2f0752d1f5 100644
  
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
+ import "crypto/internal/backend/boringtest"
  
  func TestKeyGeneration(t *testing.T) {
- 	for _, size := range []int{128, 1024, 2048, 3072} {
-@@ -26,7 +26,7 @@ func TestKeyGeneration(t *testing.T) {
+@@ -27,7 +27,7 @@ func TestKeyGeneration(t *testing.T) {
  		if bits := priv.N.BitLen(); bits != size {
  			t.Errorf("key too short (%d vs %d)", bits, size)
  		}
@@ -1369,7 +1369,7 @@ index dc502cae8f..2f0752d1f5 100644
  			t.Logf("skipping short key with BoringCrypto: %d", size)
  			continue;
  		}
-@@ -118,7 +118,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
+@@ -119,7 +119,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		t.Errorf("private exponent too large")
  	}
  
@@ -1378,7 +1378,7 @@ index dc502cae8f..2f0752d1f5 100644
  		// Cannot call encrypt/decrypt with raw RSA. Test via
  		// OAEP if possible (i.e., key size is equal to or
  		// longer than 2048 bits).
-@@ -192,7 +192,7 @@ func init() {
+@@ -193,7 +193,7 @@ func init() {
  }
  
  func BenchmarkRSA2048Decrypt(b *testing.B) {
@@ -1387,7 +1387,7 @@ index dc502cae8f..2f0752d1f5 100644
  		b.Skip("no raw decrypt in BoringCrypto")
  	}
  
-@@ -218,7 +218,7 @@ func BenchmarkRSA2048Sign(b *testing.B) {
+@@ -219,7 +219,7 @@ func BenchmarkRSA2048Sign(b *testing.B) {
  }
  
  func Benchmark3PrimeRSA2048Decrypt(b *testing.B) {
@@ -1396,30 +1396,30 @@ index dc502cae8f..2f0752d1f5 100644
  		b.Skip("no raw decrypt in BoringCrypto")
  	}
  
-@@ -264,7 +264,7 @@ func TestEncryptOAEP(t *testing.T) {
+@@ -265,7 +265,7 @@ func TestEncryptOAEP(t *testing.T) {
  	n := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
--		if boring.Enabled && n.BitLen() < 2048 {
-+		if boring.Enabled() && n.BitLen() < 2048 {
+-		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
++		if boring.Enabled() && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
  			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
  			continue
  		}
-@@ -291,7 +291,7 @@ func TestDecryptOAEP(t *testing.T) {
+@@ -292,7 +292,7 @@ func TestDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
--		if boring.Enabled && n.BitLen() < 2048 {
-+		if boring.Enabled() && n.BitLen() < 2048 {
+-		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
++		if boring.Enabled() && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
  			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
  			continue
  		}
-@@ -328,7 +328,7 @@ func TestEncryptDecryptOAEP(t *testing.T) {
+@@ -329,7 +329,7 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
--		if boring.Enabled && n.BitLen() < 2048 {
-+		if boring.Enabled() && n.BitLen() < 2048 {
+-		if boring.Enabled && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
++		if boring.Enabled() && !boringtest.Supports(t, "RSA1024") && n.BitLen() < 2048 {
  			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
  			continue
  		}
@@ -1660,7 +1660,7 @@ index 921cdbb7bb..a35165bcbf 100644
  	}
  	in := []byte("hello, world!")
 diff --git a/src/crypto/tls/boring.go b/src/crypto/tls/boring.go
-index 4c5c3527a4..76a0077b8c 100644
+index 140b1a3dd8..fe6fa96d28 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -2,7 +2,7 @@
@@ -1682,7 +1682,7 @@ index 4c5c3527a4..76a0077b8c 100644
         }
  }
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
-index b572a59303..10d1cf0616 100644
+index 2ae3814364..6166892f80 100644
 --- a/src/crypto/tls/boring_test.go
 +++ b/src/crypto/tls/boring_test.go
 @@ -2,14 +2,14 @@
@@ -1699,10 +1699,19 @@ index b572a59303..10d1cf0616 100644
  	"crypto/elliptic"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
  	"crypto/internal/boring/fipstls"
  	"crypto/rand"
- 	"crypto/rsa"
-@@ -365,7 +365,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -46,7 +46,7 @@ func TestBoringServerProtocolVersion(t *testing.T) {
+ 	test("VersionTLS10", VersionTLS10, "")
+ 	test("VersionTLS11", VersionTLS11, "")
+ 	test("VersionTLS12", VersionTLS12, "")
+-	if boring.Enabled && !boring.SupportsHKDF() {
++	if boring.Enabled() && !boring.SupportsHKDF() {
+ 		test("VersionTLS13", VersionTLS13, "client offered only unsupported versions")
+ 	} else {
+ 		test("VersionTLS13", VersionTLS13, "")
+@@ -388,7 +388,7 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig := testConfig.Clone()
  		serverConfig.ClientCAs = pool
  		serverConfig.ClientAuth = RequireAndVerifyClientCert
@@ -1711,7 +1720,7 @@ index b572a59303..10d1cf0616 100644
  			serverConfig.Certificates[0].Certificate = [][]byte{testRSA2048Certificate}
  			serverConfig.Certificates[0].PrivateKey = testRSA2048PrivateKey
  			serverConfig.BuildNameToCertificate()
-@@ -392,8 +392,8 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -415,8 +415,8 @@ func TestBoringCertAlgs(t *testing.T) {
  	// exhaustive test with computed answers.
  	r1pool := x509.NewCertPool()
  	r1pool.AddCert(R1.cert)
@@ -1722,7 +1731,7 @@ index b572a59303..10d1cf0616 100644
  	fipstls.Force()
  	testServerCert(t, "basic (fips)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
  	testClientCert(t, "basic (fips, client cert)", r1pool, L2_I.key, [][]byte{L2_I.der, I_R1.der}, false)
-@@ -414,7 +414,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -437,7 +437,7 @@ func TestBoringCertAlgs(t *testing.T) {
  			leaf = L2_I
  		}
  		for i := 0; i < 64; i++ {
@@ -1731,7 +1740,7 @@ index b572a59303..10d1cf0616 100644
  			reachableFIPS := map[string]bool{leaf.parentOrg: leaf.fipsOK}
  			list := [][]byte{leaf.der}
  			listName := leaf.name
-@@ -422,7 +422,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -445,7 +445,7 @@ func TestBoringCertAlgs(t *testing.T) {
  				if cond != 0 {
  					list = append(list, c.der)
  					listName += "," + c.name
@@ -1740,7 +1749,7 @@ index b572a59303..10d1cf0616 100644
  						reachable[c.parentOrg] = true
  					}
  					if reachableFIPS[c.org] && c.fipsOK {
-@@ -446,7 +446,7 @@ func TestBoringCertAlgs(t *testing.T) {
+@@ -469,7 +469,7 @@ func TestBoringCertAlgs(t *testing.T) {
  					if cond != 0 {
  						rootName += "," + c.name
  						pool.AddCert(c.cert)
@@ -1780,6 +1789,28 @@ index f7c64dba42..703d5c74e0 100644
  		aead, err = boring.NewGCMTLS(aes)
  	} else {
  		boring.Unreachable()
+diff --git a/src/crypto/tls/common.go b/src/crypto/tls/common.go
+index 3b3e166abc..02acc7f2b1 100644
+--- a/src/crypto/tls/common.go
++++ b/src/crypto/tls/common.go
+@@ -12,7 +12,7 @@ import (
+ 	"crypto/ecdsa"
+ 	"crypto/ed25519"
+ 	"crypto/elliptic"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/rand"
+ 	"crypto/rsa"
+ 	"crypto/sha512"
+@@ -985,7 +985,7 @@ const roleServer = false
+ func (c *Config) supportedVersions(isClient bool) []uint16 {
+ 	versions := make([]uint16, 0, len(supportedVersions))
+ 	for _, v := range supportedVersions {
+-		if boring.Enabled && !boring.SupportsHKDF() && v > VersionTLS12 {
++		if boring.Enabled() && !boring.SupportsHKDF() && v > VersionTLS12 {
+ 			continue
+ 		}
+ 		if needFIPS() && (v < fipsMinVersion(c) || v > fipsMaxVersion(c)) {
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index 323d683788..8bcee17545 100644
 --- a/src/crypto/tls/key_schedule.go
@@ -1858,7 +1889,7 @@ index 095b58c315..ac06591ea8 100644
  package x509
  
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
-index 90fe2a7227..123688d8e5 100644
+index c742e4992f..907f6c6423 100644
 --- a/src/crypto/x509/boring_test.go
 +++ b/src/crypto/x509/boring_test.go
 @@ -2,7 +2,7 @@
@@ -1884,7 +1915,7 @@ index c83a7272c9..0c7dea2f1f 100644
  package x509
  
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
-index 54cba993fe..a38ad0cf7a 100644
+index e7c7ee63c8..5262ffcb18 100644
 --- a/src/crypto/x509/x509_test.go
 +++ b/src/crypto/x509/x509_test.go
 @@ -11,7 +11,7 @@ import (
@@ -1893,10 +1924,10 @@ index 54cba993fe..a38ad0cf7a 100644
  	"crypto/elliptic"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
  	"crypto/rand"
  	"crypto/rsa"
- 	_ "crypto/sha256"
-@@ -637,7 +637,7 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
+@@ -638,7 +638,7 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
  
  	for _, test := range tests {
@@ -1906,24 +1937,24 @@ index 54cba993fe..a38ad0cf7a 100644
  			if key.PublicKey.N.BitLen() < 2048 {
  				t.Logf("skipping short key with BoringCrypto: %d", key.PublicKey.N.BitLen())
 diff --git a/src/go.mod b/src/go.mod
-index 6c316312a2..684d821b4f 100644
+index 6c316312a2..898db27279 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.19
  
  require (
-+	github.com/golang-fips/openssl-fips v0.0.0-20221202231511-5dbcdfb69806
++	github.com/golang-fips/openssl-fips v0.0.0-20230119221410-41938ace180b
  	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8
  	golang.org/x/net v0.0.0-20220907013720-d52c520e3766
  )
 diff --git a/src/go.sum b/src/go.sum
-index 2f90a33f3a..f6f32e95a0 100644
+index 2f90a33f3a..45c51943cd 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl-fips v0.0.0-20221202231511-5dbcdfb69806 h1:lvokU5Yuf9+Ix3w6lSx+/K23uC638vQMvE9Eh2IRT3A=
-+github.com/golang-fips/openssl-fips v0.0.0-20221202231511-5dbcdfb69806/go.mod h1:V2IU8imz/VkScnIbTOrdYsZ5R88ZFypCE0LzhRJ3HsI=
++github.com/golang-fips/openssl-fips v0.0.0-20230119221410-41938ace180b h1:vR12vf+jpef9wBsXU6wT5GQJiuAvyBZ+Yj5l7TRb4nY=
++github.com/golang-fips/openssl-fips v0.0.0-20230119221410-41938ace180b/go.mod h1:V2IU8imz/VkScnIbTOrdYsZ5R88ZFypCE0LzhRJ3HsI=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 h1:y+mHpWoQJNAHt26Nhh6JP7hvM71IRZureyvZhoVALIs=
  golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
  golang.org/x/net v0.0.0-20220907013720-d52c520e3766 h1:D02YdIT3M6OQkZXTQiO761u/SmR3DDDiDXLN2oZIUac=
@@ -2800,10 +2831,10 @@ index 884c4b746d..5e1e789da0 100644
  }
 diff --git a/src/vendor/github.com/golang-fips/openssl-fips/openssl/goopenssl.h b/src/vendor/github.com/golang-fips/openssl-fips/openssl/goopenssl.h
 new file mode 100644
-index 0000000000..306a9093da
+index 0000000000..23f1f5c58c
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl-fips/openssl/goopenssl.h
-@@ -0,0 +1,950 @@
+@@ -0,0 +1,1023 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -2817,6 +2848,7 @@ index 0000000000..306a9093da
 +
 +#include <stdlib.h> // size_t
 +#include <stdint.h> // uint8_t
++#include <string.h> // memset
 +
 +#include <openssl/ossl_typ.h>
 +
@@ -3171,13 +3203,61 @@ index 0000000000..306a9093da
 +DEFINEFUNC(unsigned int, BN_num_bits, (const GO_BIGNUM *arg0), (arg0))
 +DEFINEFUNC(int, BN_is_negative, (const GO_BIGNUM *arg0), (arg0))
 +DEFINEFUNC(GO_BIGNUM *, BN_bin2bn, (const uint8_t *arg0, size_t arg1, GO_BIGNUM *arg2), (arg0, arg1, arg2))
-+DEFINEFUNC(GO_BIGNUM *, BN_lebin2bn, (const unsigned char *s, size_t len, BIGNUM *ret), (s, len, ret))
-+DEFINEFUNC(int, BN_bn2lebinpad, (const BIGNUM *a, unsigned char *to, size_t tolen), (a, to, tolen))
 +
-+static inline unsigned int
++static inline int
 +_goboringcrypto_BN_num_bytes(const GO_BIGNUM* a) {
 +	return ((_goboringcrypto_BN_num_bits(a)+7)/8);
 +}
++
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++DEFINEFUNC(GO_BIGNUM *, BN_lebin2bn, (const unsigned char *s, size_t len, BIGNUM *ret), (s, len, ret))
++DEFINEFUNC(int, BN_bn2lebinpad, (const BIGNUM *a, unsigned char *to, size_t tolen), (a, to, tolen))
++#else
++DEFINEFUNCINTERNAL(int, BN_bn2bin, (const BIGNUM *a, unsigned char *to), (a, to))
++
++static inline GO_BIGNUM *
++_goboringcrypto_BN_lebin2bn(const unsigned char *s, size_t len, BIGNUM *ret)
++{
++	unsigned char *copy;
++	size_t i;
++	GO_BIGNUM *result;
++
++	copy = malloc(len);
++	if (!copy)
++		return NULL;
++	for (i = 0; i < len; i++)
++		copy[i] = s[len - i - 1];
++
++	result = _goboringcrypto_BN_bin2bn(copy, len, ret);
++	free(copy);
++	return result;
++}
++
++static inline int
++_goboringcrypto_BN_bn2lebinpad(const BIGNUM *a, unsigned char *to, size_t tolen)
++{
++	int size = _goboringcrypto_BN_num_bytes(a);
++	size_t i;
++
++	if (size > tolen)
++		return -1;
++
++	memset(to, 0, tolen - size);
++	if (_goboringcrypto_internal_BN_bn2bin(a, to + tolen - size) != size)
++		return -1;
++
++	/* reverse bytes */
++	for (i = 0; i < tolen / 2; i++) {
++		unsigned char tmp;
++
++		tmp = to[i];
++		to[i] = to[tolen - i - 1];
++		to[tolen - i - 1] = tmp;
++	}
++
++	return tolen;
++}
++#endif
 +
 +#include <openssl/ec.h>
 +
@@ -3201,7 +3281,6 @@ index 0000000000..306a9093da
 +
 +DEFINEFUNC(GO_EC_KEY *, EC_KEY_new, (void), ())
 +DEFINEFUNC(GO_EC_KEY *, EC_KEY_new_by_curve_name, (int arg0), (arg0))
-+DEFINEFUNC(int, EC_KEY_oct2key, (GO_EC_KEY *arg0, const unsigned char *arg1, size_t arg2, BN_CTX *arg3), (arg0, arg1, arg2, arg3))
 +DEFINEFUNC(void, EC_KEY_free, (GO_EC_KEY * arg0), (arg0))
 +DEFINEFUNC(const GO_EC_GROUP *, EC_KEY_get0_group, (const GO_EC_KEY *arg0), (arg0))
 +DEFINEFUNC(int, EC_KEY_set_group, (GO_EC_KEY *arg0, const EC_GROUP *arg1), (arg0, arg1))
@@ -3210,6 +3289,31 @@ index 0000000000..306a9093da
 +DEFINEFUNC(int, EC_KEY_set_public_key, (GO_EC_KEY * arg0, const GO_EC_POINT *arg1), (arg0, arg1))
 +DEFINEFUNC(const GO_BIGNUM *, EC_KEY_get0_private_key, (const GO_EC_KEY *arg0), (arg0))
 +DEFINEFUNC(const GO_EC_POINT *, EC_KEY_get0_public_key, (const GO_EC_KEY *arg0), (arg0))
++
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++DEFINEFUNC(int, EC_KEY_oct2key, (GO_EC_KEY *arg0, const unsigned char *arg1, size_t arg2, BN_CTX *arg3), (arg0, arg1, arg2, arg3))
++#else
++DEFINEFUNCINTERNAL(int, EC_POINT_oct2point, (const EC_GROUP *arg0, EC_POINT *arg1, const unsigned char *arg2, size_t arg3, BN_CTX *arg4), (arg0, arg1, arg2, arg3, arg4))
++
++static inline int
++_goboringcrypto_EC_KEY_oct2key(GO_EC_KEY *eckey, const unsigned char *buf, size_t len, BN_CTX *ctx)
++{
++	const GO_EC_GROUP *group = _goboringcrypto_EC_KEY_get0_group(eckey);
++	GO_EC_POINT *pubkey;
++	int ret = 1;
++
++	pubkey = _goboringcrypto_EC_POINT_new(group);
++	if (!pubkey)
++		return 0;
++
++	if (_goboringcrypto_internal_EC_POINT_oct2point(group, pubkey, buf, len, ctx) != 1 ||
++	    _goboringcrypto_EC_KEY_set_public_key(eckey, pubkey) != 1)
++		ret = 0;
++
++	_goboringcrypto_EC_POINT_free(pubkey);
++	return ret;
++}
++#endif
 +
 +// TODO: EC_KEY_check_fips?
 +
@@ -3756,10 +3860,10 @@ index 0000000000..306a9093da
 +#endif
 diff --git a/src/vendor/github.com/golang-fips/openssl-fips/openssl/hkdf.go b/src/vendor/github.com/golang-fips/openssl-fips/openssl/hkdf.go
 new file mode 100644
-index 0000000000..4328a5c005
+index 0000000000..2e21224264
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl-fips/openssl/hkdf.go
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,108 @@
 +// Copyright 2017 The Go Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style
 +// license that can be found in the LICENSE file.
@@ -3779,6 +3883,10 @@ index 0000000000..4328a5c005
 +
 +type hkdf struct {
 +	ctx *C.GO_EVP_PKEY_CTX
++}
++
++func SupportsHKDF() bool {
++	return openSSLVersion() >= OPENSSL_VERSION_1_1_1
 +}
 +
 +func newHKDF(h func() hash.Hash, mode C.int) (*hkdf, error) {
@@ -5893,11 +6001,11 @@ index 15b50c90d3..0b55cedc91 100644
  
  type sha512Ctx struct {
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 35c0208e4e..c0f82c6fa4 100644
+index 35c0208e4e..f938b9d914 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,6 @@
-+# github.com/golang-fips/openssl-fips v0.0.0-20221202231511-5dbcdfb69806
++# github.com/golang-fips/openssl-fips v0.0.0-20230119221410-41938ace180b
 +## explicit; go 1.18
 +github.com/golang-fips/openssl-fips/openssl
  # golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8

--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -252,6 +252,59 @@ index d12ba2f441..6334a56496 100644
  		return
  	}
  	testHashSignAndHashVerify(t, elliptic.P384(), "p384")
+diff --git a/src/crypto/ecdsa/ecdsa_test.go b/src/crypto/ecdsa/ecdsa_test.go
+index db56cdd26e..22ad807124 100644
+--- a/src/crypto/ecdsa/ecdsa_test.go
++++ b/src/crypto/ecdsa/ecdsa_test.go
+@@ -12,7 +12,7 @@ import (
+ 	"crypto/sha1"
+ 	"crypto/sha256"
+ 	"crypto/sha512"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
+ 	"encoding/hex"
+ 	"hash"
+@@ -34,7 +34,7 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+ 	}
+ 	if testing.Short() {
+ 		tests = tests[:1]
+-	} else if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
++	} else if !boring.Enabled() || boringtest.Supports(t, "CurveP224") {
+ 		p224 := struct {
+ 			name  string
+ 			curve elliptic.Curve
+@@ -230,7 +230,7 @@ func TestVectors(t *testing.T) {
+ 
+ 			switch curve {
+ 			case "P-224":
+-				if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
++				if !boring.Enabled() || boringtest.Supports(t, "CurveP224") {
+ 					pub.Curve = elliptic.P224()
+ 				} else {
+ 					pub.Curve = nil
+diff --git a/src/crypto/ecdsa/equal_test.go b/src/crypto/ecdsa/equal_test.go
+index 4371e31b1a..5ef62abe37 100644
+--- a/src/crypto/ecdsa/equal_test.go
++++ b/src/crypto/ecdsa/equal_test.go
+@@ -10,7 +10,7 @@ import (
+ 	"crypto/elliptic"
+ 	"crypto/rand"
+ 	"crypto/x509"
+-	"crypto/internal/boring"
++	boring "crypto/internal/backend"
+ 	"crypto/internal/backend/boringtest"
+ 	"testing"
+ )
+@@ -71,7 +71,7 @@ func TestEqual(t *testing.T) {
+ 	if testing.Short() {
+ 		return
+ 	}
+-	if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
++	if !boring.Enabled() || boringtest.Supports(t, "CurveP224") {
+ 		t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
+ 	}
+ 	t.Run("P384", func(t *testing.T) { testEqual(t, elliptic.P384()) })
 diff --git a/src/crypto/ecdsa/notboring.go b/src/crypto/ecdsa/notboring.go
 index 039bd82ed2..21a35b760c 100644
 --- a/src/crypto/ecdsa/notboring.go
@@ -1159,7 +1212,7 @@ index ab19229a6c..87b0ec98d9 100644
  		}
  		return nil
 diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
-index 4383108679..7e01801f9e 100644
+index c9c5ebcc04..f6afc363ea 100644
 --- a/src/crypto/rsa/pkcs1v15_test.go
 +++ b/src/crypto/rsa/pkcs1v15_test.go
 @@ -7,7 +7,7 @@ package rsa
@@ -1175,8 +1228,8 @@ index 4383108679..7e01801f9e 100644
  }
  
  func TestDecryptPKCS1v15(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
+-	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1184,8 +1237,8 @@ index 4383108679..7e01801f9e 100644
  }
  
  func TestEncryptPKCS1v15(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
+-	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1193,8 +1246,8 @@ index 4383108679..7e01801f9e 100644
  }
  
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
+-	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1202,8 +1255,8 @@ index 4383108679..7e01801f9e 100644
  }
  
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
+-	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1211,8 +1264,8 @@ index 4383108679..7e01801f9e 100644
  }
  
  func TestShortSessionKey(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "PKCSv1.5") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "PKCSv1.5") {
+-	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
++	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
  
@@ -1257,7 +1310,7 @@ index 29e79bd342..e7431e8062 100644
  		if err != nil {
  			return err
 diff --git a/src/crypto/rsa/pss_test.go b/src/crypto/rsa/pss_test.go
-index ad82d4456f..4ba0c23340 100644
+index eceb31aa71..6b6530e625 100644
 --- a/src/crypto/rsa/pss_test.go
 +++ b/src/crypto/rsa/pss_test.go
 @@ -9,7 +9,7 @@ import (
@@ -1273,8 +1326,8 @@ index ad82d4456f..4ba0c23340 100644
  // TestPSSGolden tests all the test vectors in pss-vect.txt from
  // ftp://ftp.rsasecurity.com/pub/pkcs/pkcs-1/pkcs-1v2-1-vec.zip
  func TestPSSGolden(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "SHA1") {
+-	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
++	if boring.Enabled() && !boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: SHA-1 not allowed")
  	}
  	inFile, err := os.Open("testdata/pss-vect.txt.bz2")
@@ -1291,8 +1344,8 @@ index ad82d4456f..4ba0c23340 100644
  }
  
  func TestPSSSigning(t *testing.T) {
--	if boring.Enabled && ! boringtest.Supports(t, "SHA1") {
-+	if boring.Enabled() && ! boringtest.Supports(t, "SHA1") {
+-	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
++	if boring.Enabled() && !boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
  
@@ -1915,7 +1968,7 @@ index c83a7272c9..0c7dea2f1f 100644
  package x509
  
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
-index e7c7ee63c8..5262ffcb18 100644
+index f5ce78166e..f9a0f1306d 100644
 --- a/src/crypto/x509/x509_test.go
 +++ b/src/crypto/x509/x509_test.go
 @@ -11,7 +11,7 @@ import (
@@ -1936,6 +1989,15 @@ index e7c7ee63c8..5262ffcb18 100644
  			key, _ := test.priv.(*rsa.PrivateKey)
  			if key.PublicKey.N.BitLen() < 2048 {
  				t.Logf("skipping short key with BoringCrypto: %d", key.PublicKey.N.BitLen())
+@@ -3578,7 +3578,7 @@ func TestRevocationListCheckSignatureFrom(t *testing.T) {
+ 	var testCurve elliptic.Curve
+ 	// If OpenSSL supports P224, use the default upstream behavior,
+ 	// otherwise test with P384
+-	if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
++	if !boring.Enabled() || boringtest.Supports(t, "CurveP224") {
+ 		testCurve = elliptic.P224()
+ 	} else {
+ 		testCurve = elliptic.P384()
 diff --git a/src/go.mod b/src/go.mod
 index 6c316312a2..898db27279 100644
 --- a/src/go.mod

--- a/scripts/configure-crypto-tests.sh
+++ b/scripts/configure-crypto-tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+# Try PLATFORM_ID
+OS_ID=$(cat /etc/os-release | awk 'match($0,/PLATFORM_ID="platform:(.*)"/,a){print a[1]}')
+if [[ "$OS_ID" == "" ]]; then
+# Try REDHAT_BUGZILLA_PRODUCT
+  OS_ID=$(cat /etc/os-release | awk 'match($0,/REDHAT_BUGZILLA_PRODUCT=\"(.*)\"/,a){print a[1]}')
+fi
+
+
+ROOT=$(realpath $(dirname $(readlink -f $0))/..)
+CONFIG=$ROOT/go/src/crypto/internal/backend/boringtest/config.go
+
+set_param () {
+  local param=$1
+  local val=$2
+  echo "Setting $param to $val."
+  sed -i "s/\"$param\":.*,/\"$param\": $val,/" $CONFIG
+}
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "could not find $CONFIG"
+fi
+
+if [[ "$OS_ID" == "el9" ]]; then
+  echo "Detected el9..."
+  echo "Keeping current settings."
+elif [[ "$OS_ID" == "el8" ]]; then
+  echo "Detected el8..."
+  set_param "PKCSv1.5" "true"
+  set_param "SHA1" "true"
+  set_param "RSA4096LeafCert" "true"
+  set_param "RSA1024LeafCert" "true"
+  set_param "TLS13" "true"
+  set_param "CurveP224" "true"
+elif [[ "$OS_ID" == "Red Hat Enterprise Linux 7" ]]; then
+  echo "Detected el7..."
+  set_param "PKCSv1.5" "true"
+  set_param "SHA1" "true"
+  set_param "RSA4096LeafCert" "false"
+  set_param "RSA1024LeafCert" "true"
+  set_param "TLS13" "false"
+  set_param "CurveP224" "false"
+else
+  echo "Detected unknown os: $OS_ID ..."
+  echo "Keeping current settings."
+fi
+


### PR DESCRIPTION
Variations in behavior between OpenSSL versions and distributions often causes the crypto test suite to be incompatible when porting between linux distros. This PR introduces a TestConfig backend for more easily configuring the crypto test suite in FIPS mode.

To configure which algorithms and key types are supported by OpenSSL, adjustments can now be made to the paramaters in `crypto/internal/backend/boringtest/config.go`  A script is also added for convenience.

This PR also disables TLSv1.3 for OpenSSL versions older than v1.1.1, which fixes crashes when using those versions.  This was batched in because there was a lot of overlap in the implementation work.