### PR TITLE
Skip test case in TestEncryptOAEP with unsupported padding

### DIFF
--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -296,7 +296,7 @@ new file mode 100644
 index 0000000000..6c8c00d11e
 --- /dev/null
 +++ b/src/crypto/internal/backend/boringtest/config.go
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,47 @@
 +/* Test configuration package for OpenSSL FIPS
 +
 +The FIPS mode behavior of OpenSSL varies between versions and distributions
@@ -333,6 +333,7 @@ index 0000000000..6c8c00d11e
 +		"CurveP256": true,
 +		"CurveP384": true,
 +		"CurveP521": true,
++		"RSANoPadding": false,
 +	}
 +}
 +
@@ -1097,6 +1098,21 @@ index ba68f355eb..8ddd2526c7 100644
  		return true
  	}
  	return false
+@@ -226,6 +236,14 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
+ 			// 1.3, and the ECDSA ones bind to the curve used.
+ 			serverConfig.MaxVersion = VersionTLS12
+ 
++			if boring.Enabled && !boringtest.Supports(t, "RSANoPadding") {
++				switch sigHash {
++				case PSSWithSHA256, PSSWithSHA384, PSSWithSHA512:
++					t.Skip("Unsupported in FIPS mode")
++					return
++				}
++			}
++
+ 			clientErr, serverErr := boringHandshake(t, testConfig, serverConfig)
+ 			if clientErr != nil {
+ 				t.Fatalf("expected handshake with %#x to succeed; client error: %v; server error: %v", sigHash, clientErr, serverErr)
 @@ -315,15 +325,31 @@ func TestBoringCertAlgs(t *testing.T) {
  	R2 := boringCert(t, "R2", boringRSAKey(t, 512), nil, boringCertCA)
 

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -954,7 +954,7 @@ index 3278a7ff30..e4484540c1 100644
  			testEverything(t, priv)
  		})
  	}
-@@ -629,6 +667,10 @@ func TestEncryptOAEP(t *testing.T) {
+@@ -629,6 +667,14 @@ func TestEncryptOAEP(t *testing.T) {
  	n := new(big.Int)
  	for i, test := range testEncryptOAEPData {
  		n.SetString(test.modulus, 16)
@@ -962,6 +962,10 @@ index 3278a7ff30..e4484540c1 100644
 +			t.Logf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +			continue
 +		}
++ 	if boring.Enabled && i == 1 {
++ 		t.Log("skipping due to unsupported padding usage")
++ 		continue
++ 	}
  		public := PublicKey{N: n, E: test.e}
 
  		for j, message := range test.msgs {


### PR DESCRIPTION
Skips a test case which fails on RHEL9 due to a change in the openssl FIPS provider which enforces stricter constraints on padding.