### PR TITLE
Go1.20.6

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "github.com/golang-fips/go": "go1.20-fips-release",
     "github.com/golang-fips/openssl-fips": "e1541889d8a8ad4eaf02630a8cae303206ef68c1",
-    "github.com/golang/go": "go1.20.5"
+    "github.com/golang/go": "go1.20.6"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "github.com/golang-fips/go": "go1.20-fips-release",
-    "github.com/golang-fips/openssl-fips": "e1541889d8a8ad4eaf02630a8cae303206ef68c1",
+    "github.com/golang-fips/openssl-fips": "9051f24728fe7141015889776bc44949c2b4cf1e",
     "github.com/golang/go": "go1.20.6"
 }

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -16,17 +16,17 @@ index 4aaf46b5d0..c231e299d9 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 @@ -21,11 +21,11 @@ go build .
-
+ 
  go list -deps -f '{{.ImportPath}} {{.Dir}}' .
  stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
 -! stdout $GOROOT[/\\]src[/\\]vendor
 +! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
-
+ 
  go list -test -deps -f '{{.ImportPath}} {{.Dir}}' .
  stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
 -! stdout $GOROOT[/\\]src[/\\]vendor
 +! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
-
+ 
  -- issue16333/issue16333.go --
  package vendoring17
 diff --git a/src/crypto/ecdh/ecdh_test.go b/src/crypto/ecdh/ecdh_test.go
@@ -151,7 +151,7 @@ index 0000000000..d12ba2f441
 +	testHashSignAndHashVerify(t, elliptic.P521(), "p521")
 +}
 diff --git a/src/crypto/ecdsa/ecdsa_test.go b/src/crypto/ecdsa/ecdsa_test.go
-index 95c78c8e32..51f58b305e 100644
+index 08a0903eb1..61a4662036 100644
 --- a/src/crypto/ecdsa/ecdsa_test.go
 +++ b/src/crypto/ecdsa/ecdsa_test.go
 @@ -9,6 +9,8 @@ import (
@@ -160,10 +160,10 @@ index 95c78c8e32..51f58b305e 100644
  	"crypto/elliptic"
 +	"crypto/internal/backend/boringtest"
 +	"crypto/internal/boring"
+ 	"crypto/internal/bigmod"
  	"crypto/rand"
  	"crypto/sha1"
- 	"crypto/sha256"
-@@ -35,8 +37,17 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+@@ -36,8 +38,17 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
  	}
  	if testing.Short() {
  		tests = tests[:1]
@@ -181,8 +181,8 @@ index 95c78c8e32..51f58b305e 100644
  		curve := test.curve
  		t.Run(test.name, func(t *testing.T) {
  			t.Parallel()
-@@ -234,7 +245,11 @@ func TestVectors(t *testing.T) {
-
+@@ -235,7 +246,11 @@ func TestVectors(t *testing.T) {
+ 
  			switch curve {
  			case "P-224":
 -				pub.Curve = elliptic.P224()
@@ -206,10 +206,10 @@ index 53ac8504c2..4371e31b1a 100644
 +	"crypto/internal/backend/boringtest"
  	"testing"
  )
-
+ 
 @@ -65,11 +67,13 @@ func testEqual(t *testing.T, c elliptic.Curve) {
  }
-
+ 
  func TestEqual(t *testing.T) {
 -	t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
 +	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })
@@ -229,7 +229,7 @@ index 47c8698e2a..8b5c2cc9af 100644
 +++ b/src/crypto/ed25519/ed25519_test.go
 @@ -321,6 +321,7 @@ func TestMalleability(t *testing.T) {
  }
-
+ 
  func TestAllocations(t *testing.T) {
 +	t.Skip("Allocations test broken with openssl linkage")
  	if boring.Enabled {
@@ -241,11 +241,11 @@ index f933f2800a..223ce04340 100644
 +++ b/src/crypto/ed25519/ed25519vectors_test.go
 @@ -72,6 +72,7 @@ func TestEd25519Vectors(t *testing.T) {
  }
-
+ 
  func downloadEd25519Vectors(t *testing.T) []byte {
 +	t.Skip("skipping test that downloads external data")
  	testenv.MustHaveExternalNetwork(t)
-
+ 
  	// Create a temp dir and modcache subdir.
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
@@ -642,7 +642,7 @@ index dfa1eddc88..39a4fc184a 100644
  	"crypto/sha1"
 @@ -54,6 +56,10 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
-
+ 
  func TestDecryptPKCS1v15(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -653,7 +653,7 @@ index dfa1eddc88..39a4fc184a 100644
  			return DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
 @@ -78,6 +84,10 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
-
+ 
  func TestEncryptPKCS1v15(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -661,10 +661,10 @@ index dfa1eddc88..39a4fc184a 100644
 +
  	random := rand.Reader
  	k := (rsaPrivateKey.N.BitLen() + 7) / 8
-
+ 
 @@ -139,6 +149,10 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
-
+ 
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -675,7 +675,7 @@ index dfa1eddc88..39a4fc184a 100644
  		err := DecryptPKCS1v15SessionKey(nil, rsaPrivateKey, decodeBase64(test.in), key)
 @@ -153,6 +167,10 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
-
+ 
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -691,21 +691,21 @@ index dfa1eddc88..39a4fc184a 100644
 -	{"Test.\n", "a4f3fa6ea93bcdd0c57be020c1193ecbfd6f200a3d95c409769b029578fa0e336ad9a347600e40d3ae823b8c7e6bad88cc07c1d54c3a1523cbbb6d58efc362ae"},
 +	{"Test.\n", "0c7c85d938862248846cba06b06ac9bfe752aafed3092c224f257855006aa35b43d101e6c8e59cbc4c20b07c81552963f189dea700e042d4b70c236a031a29a9273cc138e69dc1a5834491de4822d8cb6acf218789d2586cb0f3892236b0948ffaf8691f6fa04597caa45068f9be39b8ea8b5336a8c94e2696f872120778abcfea711e5fbf75f835f0f5204ccdd020013c2ceae25e9d1378a1d10cf86ca269eef48fee8ebb5e8dfb08f0c48d22d1a7162e080ec1f6e48541288aaaa1f2370f0688cf1786a32abed41df1d3b96b665794bf7a772743fc8b62d73901cea4569494c794a01ccc7dda0d42199f5b58739c0c0e280774b56ccf51993f5ea3d4954319"},
  }
-
+ 
  func TestSignPKCS1v15(t *testing.T) {
 @@ -201,7 +219,7 @@ func TestSignPKCS1v15(t *testing.T) {
  		h.Write([]byte(test.in))
  		digest := h.Sum(nil)
-
+ 
 -		s, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.SHA1, digest)
 +		s, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.SHA1, digest)
  		if err != nil {
  			t.Errorf("#%d %s", i, err)
  		}
 @@ -221,7 +239,7 @@ func TestVerifyPKCS1v15(t *testing.T) {
-
+ 
  		sig, _ := hex.DecodeString(test.out)
-
+ 
 -		err := VerifyPKCS1v15(&rsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
 +		err := VerifyPKCS1v15(&boringRsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
  		if err != nil {
@@ -717,7 +717,7 @@ index dfa1eddc88..39a4fc184a 100644
  	// file.
 -	expectedSig := decodeBase64("pX4DR8azytjdQ1rtUiC040FjkepuQut5q2ZFX1pTjBrOVKNjgsCDyiJDGZTCNoh9qpXYbhl7iEym30BWWwuiZg==")
 +	expectedSig := decodeBase64("XgDn6nJdfL/gY3eq15l9Va41/nNkDrkTlxOZYHYeFaMOW+Z4BHTCZ1LhqNBXOBK9XEyHho6okpY4rqE1zTIVX/kCGJ+jS6VRgUsHcTcpvKBYZCW84yrjE360gkntzkGxUF9FaiOGzmJKwBm1UvFgFIaYlvF+PdU0H1trBvm/RYRU42xOQRY1U+MSXgruFfINE20vPTlAG22uJ2CELrZUDykQGnrDFsEP0UqyyyiqGqxHt8E7iNYC6+xhPPC/ato9Bev08nu/U/EGH2imifSoNz/IN6h3fQClHwk1a74bPrcRsmUAAHOX2X1VKxK7IruinU8iOyoG6oFuvT+QlMnWAw==")
-
+ 
 -	sig, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.Hash(0), msg)
 +	sig, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.Hash(0), msg)
  	if err != nil {
@@ -731,7 +731,7 @@ index dfa1eddc88..39a4fc184a 100644
  		t.Fatalf("signature failed to verify: %s", err)
  	}
  }
-
+ 
  func TestShortSessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -743,7 +743,7 @@ index dfa1eddc88..39a4fc184a 100644
 @@ -297,6 +319,35 @@ func parsePublicKey(s string) *PublicKey {
  	return k
  }
-
+ 
 +
 +var boringRsaPrivateKey = parseKey(testingKey(`-----BEGIN RSA TESTING KEY-----
 +MIIEogIBAAKCAQEAp5qgUIj096pw8U+AjcJucLWenR3oe+tEthXiAuqcYgslW5UU
@@ -813,11 +813,11 @@ index cf03e3cb7e..1226149321 100644
 @@ -195,10 +204,15 @@ func TestPSSNilOpts(t *testing.T) {
  	h.Write([]byte("testing"))
  	hashed := h.Sum(nil)
-
+ 
 +	// Shouldn't this check return value?
  	SignPSS(rand.Reader, rsaPrivateKey, hash, hashed, nil)
  }
-
+ 
  func TestPSSSigning(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: too short key")
@@ -829,7 +829,7 @@ index cf03e3cb7e..1226149321 100644
 @@ -236,11 +250,15 @@ func TestPSSSigning(t *testing.T) {
  	}
  }
-
+ 
 -func TestPSS513(t *testing.T) {
 +// This previously tested PSSSaltLengthAuto
 +// We'll change the key here to 2048 bits to
@@ -852,12 +852,12 @@ index cf03e3cb7e..1226149321 100644
 +	}); err.Error() != InvalidSaltLenErr.Error() && !strings.Contains(err.Error(), "RSA_sign_pss_mgf1 failed") {
  		t.Fatalf("SignPSS unexpected error: got %v, want %v", err, InvalidSaltLenErr)
  	}
-
+ 
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
-index 11f87e8e49..bdd6d85c69 100644
+index 63bc8dad1a..ab56ccd1ed 100644
 --- a/src/crypto/rsa/rsa.go
 +++ b/src/crypto/rsa/rsa.go
-@@ -508,7 +508,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
+@@ -509,7 +509,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
  		if err != nil {
  			return nil, err
  		}
@@ -865,8 +865,8 @@ index 11f87e8e49..bdd6d85c69 100644
 +		return boring.EncryptRSAOAEP(hash, bkey, msg, label)
  	}
  	boring.UnreachableExceptTests()
-
-@@ -679,7 +679,7 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
+ 
+@@ -680,7 +680,7 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
  		if err != nil {
  			return nil, err
  		}
@@ -876,13 +876,13 @@ index 11f87e8e49..bdd6d85c69 100644
  			return nil, ErrDecryption
  		}
 diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
-index 3278a7ff30..e4484540c1 100644
+index 3278a7ff30..b994daec19 100644
 --- a/src/crypto/rsa/rsa_test.go
 +++ b/src/crypto/rsa/rsa_test.go
 @@ -23,6 +23,8 @@ import (
  	"testing"
  )
-
+ 
 +import "crypto/internal/backend/boringtest"
 +
  func TestKeyGeneration(t *testing.T) {
@@ -902,7 +902,7 @@ index 3278a7ff30..e4484540c1 100644
 @@ -114,6 +120,35 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		t.Errorf("private exponent too large")
  	}
-
+ 
 +	if boring.Enabled {
 +		// Cannot call encrypt/decrypt with raw RSA. PKCSv1.5
 +		// not supported in some configurations.  Test with
@@ -938,7 +938,7 @@ index 3278a7ff30..e4484540c1 100644
 @@ -121,7 +156,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		return
  	}
-
+ 
 -	dec, err := DecryptPKCS1v15(nil, priv, enc)
 +	dec, err := DecryptPKCS1v15(rand.Reader, priv, enc)
  	if err != nil {
@@ -963,7 +963,7 @@ index 3278a7ff30..e4484540c1 100644
 +			continue
 +		}
  		public := PublicKey{N: n, E: test.e}
-
+ 
  		for j, message := range test.msgs {
 @@ -652,6 +694,10 @@ func TestDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
@@ -979,13 +979,13 @@ index 3278a7ff30..e4484540c1 100644
 @@ -695,6 +741,10 @@ func Test2DecryptOAEP(t *testing.T) {
  	sha1 := crypto.SHA1
  	sha256 := crypto.SHA256
-
+ 
 +	if boring.Enabled && n.BitLen() < 2048 {
 +		t.Skipf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +	}
 +
  	out, err := priv.Decrypt(random, in, &OAEPOptions{MGFHash: sha1, Hash: sha256})
-
+ 
  	if err != nil {
 @@ -710,6 +760,10 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
@@ -1003,12 +1003,12 @@ index 1827f76458..140b1a3dd8 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -8,8 +8,15 @@ package tls
-
+ 
  import (
  	"crypto/internal/boring/fipstls"
 +	boring "crypto/internal/backend"
  )
-
+ 
 +func init() {
 +       if boring.Enabled && !boring.ExecutingTest() {
 +               fipstls.Force()
@@ -1019,14 +1019,14 @@ index 1827f76458..140b1a3dd8 100644
  func needFIPS() bool {
  	return fipstls.Required()
 @@ -17,14 +24,18 @@ func needFIPS() bool {
-
+ 
  // fipsMinVersion replaces c.minVersion in FIPS-only mode.
  func fipsMinVersion(c *Config) uint16 {
 -	// FIPS requires TLS 1.2.
 +	// FIPS requires TLS 1.2 or later.
  	return VersionTLS12
  }
-
+ 
  // fipsMaxVersion replaces c.maxVersion in FIPS-only mode.
  func fipsMaxVersion(c *Config) uint16 {
 -	// FIPS requires TLS 1.2.
@@ -1038,7 +1038,7 @@ index 1827f76458..140b1a3dd8 100644
 +		return VersionTLS12
 +	}
  }
-
+ 
  // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
 index ba68f355eb..7bfe3f9417 100644
@@ -1063,7 +1063,7 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		test("VersionTLS13", VersionTLS13, "")
 +	}
-
+ 
  	fipstls.Force()
  	defer fipstls.Abandon()
 @@ -52,11 +58,13 @@ func TestBoringServerProtocolVersion(t *testing.T) {
@@ -1075,12 +1075,12 @@ index ba68f355eb..7bfe3f9417 100644
 +		test("VersionTLS13", VersionTLS13, "")
 +	}
  }
-
+ 
  func isBoringVersion(v uint16) bool {
 -	return v == VersionTLS12
 +	return v == VersionTLS12 || (boring.SupportsHKDF() && v == VersionTLS13)
  }
-
+ 
  func isBoringCipherSuite(id uint16) bool {
 @@ -66,7 +74,9 @@ func isBoringCipherSuite(id uint16) bool {
  		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -1096,7 +1096,7 @@ index ba68f355eb..7bfe3f9417 100644
 @@ -226,7 +236,14 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
  			// 1.3, and the ECDSA ones bind to the curve used.
  			serverConfig.MaxVersion = VersionTLS12
-
+ 
 -			clientErr, serverErr := boringHandshake(t, testConfig, serverConfig)
 +			clientConfig := testConfig.Clone()
 +
@@ -1111,7 +1111,7 @@ index ba68f355eb..7bfe3f9417 100644
  			}
 @@ -315,15 +332,31 @@ func TestBoringCertAlgs(t *testing.T) {
  	R2 := boringCert(t, "R2", boringRSAKey(t, 512), nil, boringCertCA)
-
+ 
  	M1_R1 := boringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
 -	M2_R1 := boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
 +
@@ -1123,13 +1123,13 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		M2_R1 = boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
 +	}
-
+ 
  	I_R1 := boringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
 -	I_R2 := boringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 +	I_R2 := boringCert(t, "I_R2", I_R1.key, R2, boringCertCA)
  	I_M1 := boringCert(t, "I_M1", I_R1.key, M1_R1, boringCertCA|boringCertFIPSOK)
  	I_M2 := boringCert(t, "I_M2", I_R1.key, M2_R1, boringCertCA|boringCertFIPSOK)
-
+ 
  	L1_I := boringCert(t, "L1_I", boringECDSAKey(t, elliptic.P384()), I_R1, boringCertLeaf|boringCertFIPSOK)
 -	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf)
 +
@@ -1141,20 +1141,20 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		L2_I = boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf|boringCertNotBoring)
 +	}
-
+ 
  	// client verifying server cert
  	testServerCert := func(t *testing.T, desc string, pool *x509.CertPool, key interface{}, list [][]byte, ok bool) {
 @@ -336,6 +369,11 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig.Certificates = []Certificate{{Certificate: list, PrivateKey: key}}
  		serverConfig.BuildNameToCertificate()
-
+ 
 +		if boring.Enabled {
 +			serverConfig.Rand = boring.RandReader
 +			clientConfig.Rand = boring.RandReader
 +		}
 +
  		clientErr, _ := boringHandshake(t, clientConfig, serverConfig)
-
+ 
  		if (clientErr == nil) == ok {
 @@ -362,6 +400,16 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig := testConfig.Clone()
@@ -1170,9 +1170,9 @@ index ba68f355eb..7bfe3f9417 100644
 +			serverConfig.Rand = boring.RandReader
 +			clientConfig.Rand = boring.RandReader
 +		}
-
+ 
  		_, serverErr := boringHandshake(t, clientConfig, serverConfig)
-
+ 
 @@ -384,8 +432,8 @@ func TestBoringCertAlgs(t *testing.T) {
  	// exhaustive test with computed answers.
  	r1pool := x509.NewCertPool()
@@ -1217,7 +1217,7 @@ index ba68f355eb..7bfe3f9417 100644
  	boringCertFIPSOK = 0x80
 +	boringCertNotBoring = 0x100
  )
-
+ 
  func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
 @@ -490,6 +539,7 @@ type boringCertificate struct {
  	cert      *x509.Certificate
@@ -1225,7 +1225,7 @@ index ba68f355eb..7bfe3f9417 100644
  	fipsOK    bool
 +	notBoring bool
  }
-
+ 
  func boringCert(t *testing.T, name string, key interface{}, parent *boringCertificate, mode int) *boringCertificate {
 @@ -511,7 +561,7 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
@@ -1238,13 +1238,13 @@ index ba68f355eb..7bfe3f9417 100644
  		tmpl.IsCA = true
 @@ -548,7 +598,8 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  	}
-
+ 
  	fipsOK := mode&boringCertFIPSOK != 0
 -	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK}
 +	notBoring := mode&boringCertNotBoring != 0
 +	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK, notBoring}
  }
-
+ 
  // A self-signed test certificate with an RSA key of size 2048, for testing
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 04e6dfe018..b6ed936cd1 100644
@@ -1253,7 +1253,7 @@ index 04e6dfe018..b6ed936cd1 100644
 @@ -354,6 +354,11 @@ var defaultCipherSuitesTLS13NoAES = []uint16{
  	TLS_AES_256_GCM_SHA384,
  }
-
+ 
 +var defaultFIPSCipherSuitesTLS13 = []uint16{
 +	TLS_AES_128_GCM_SHA256,
 +	TLS_AES_256_GCM_SHA384,
@@ -1289,7 +1289,7 @@ index 63d86b9f3a..a8ee915041 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -127,7 +127,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
-
+ 
  	var key *ecdh.PrivateKey
  	if hello.supportedVersions[0] == VersionTLS13 {
 -		if hasAESGCMHardwareSupport {
@@ -1300,25 +1300,25 @@ index 63d86b9f3a..a8ee915041 100644
  		} else {
  			hello.cipherSuites = append(hello.cipherSuites, defaultCipherSuitesTLS13NoAES...)
 diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
-index 749c9fc954..2e37a1867c 100644
+index 22be38faff..d460eeb880 100644
 --- a/src/crypto/tls/handshake_client_test.go
 +++ b/src/crypto/tls/handshake_client_test.go
-@@ -2135,6 +2135,7 @@ func testBuffering(t *testing.T, version uint16) {
+@@ -2156,6 +2156,7 @@ func testBuffering(t *testing.T, version uint16) {
  }
-
+ 
  func TestAlertFlushing(t *testing.T) {
 +       t.Skip("unsupported in FIPS mode, different error returned")
  	c, s := localPipe(t)
  	done := make(chan bool)
-
+ 
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
-index fefba01a06..fa6989e619 100644
+index 4a8661085e..87fe11de5c 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
 +++ b/src/crypto/tls/handshake_client_tls13.go
 @@ -41,10 +41,6 @@ type clientHandshakeStateTLS13 struct {
  func (hs *clientHandshakeStateTLS13) handshake() error {
  	c := hs.c
-
+ 
 -	if needFIPS() {
 -		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
 -	}
@@ -1333,7 +1333,7 @@ index b7b568cd84..af75e7dbe0 100644
 @@ -44,10 +44,6 @@ type serverHandshakeStateTLS13 struct {
  func (hs *serverHandshakeStateTLS13) handshake() error {
  	c := hs.c
-
+ 
 -	if needFIPS() {
 -		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
 -	}
@@ -1392,7 +1392,7 @@ index ae8f80a7cf..30a8450f40 100644
 +		return hkdf.Extract(c.hash.New, newSecret, currentSecret)
 +	}
  }
-
+ 
  // nextTrafficSecret generates the next traffic secret, given the current one,
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
 index 33fd0ed52b..102acda578 100644
@@ -1408,7 +1408,7 @@ index 33fd0ed52b..102acda578 100644
  	"crypto/x509/pkix"
 @@ -58,7 +59,15 @@ func TestBoringAllowCert(t *testing.T) {
  	R3 := testBoringCert(t, "R3", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
-
+ 
  	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
 -	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
 +
@@ -1420,7 +1420,7 @@ index 33fd0ed52b..102acda578 100644
 +	} else {
 +		M2_R1 = testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
 +	}
-
+ 
  	I_R1 := testBoringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
  	testBoringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
@@ -1439,7 +1439,7 @@ index 8846b00312..8734dd03c1 100644
 @@ -125,32 +127,54 @@ func TestParsePKIXPublicKey(t *testing.T) {
  	})
  }
-
+ 
 +// This public key is extracted from pemPrivateKey defined below with
 +// the following command:
 +//
@@ -1462,7 +1462,7 @@ index 8846b00312..8734dd03c1 100644
 +aQIDAQAB
  -----END PUBLIC KEY-----
  `
-
+ 
 +// This key is generated with the following command:
 +//
 +//   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out key.pem
@@ -1510,9 +1510,9 @@ index 8846b00312..8734dd03c1 100644
 +QOhL8wXZcdwHKsONy55kZHo8pmneqi9EnqqLGguLwx5WIMzWvZ8=
  -----END RSA TESTING KEY-----
  `)
-
+ 
 @@ -210,13 +234,13 @@ func bigFromHexString(s string) *big.Int {
-
+ 
  var rsaPrivateKey = &rsa.PrivateKey{
  	PublicKey: rsa.PublicKey{
 -		N: bigFromString("124737666279038955318614287965056875799409043964547386061640914307192830334599556034328900586693254156136128122194531292927142396093148164407300419162827624945636708870992355233833321488652786796134504707628792159725681555822420087112284637501705261187690946267527866880072856272532711620639179596808018872997"),
@@ -1528,10 +1528,10 @@ index 8846b00312..8734dd03c1 100644
 +		bigFromString("146306182837940795154243491672545598732731521261772425577071902398494756400761181229877966908959767779942799478853764354255505873530749881845000716071915494302715554511619294255599209521952152229250381623079574375248555498847701822870266575429060940749806104053368129657146195126647000200158517816035847077797"),
  	},
  }
-
+ 
 @@ -629,6 +653,13 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
-
+ 
  	for _, test := range tests {
 +		if boring.Enabled && test.sigAlgo.isRSAPSS() {
 +			key, _ := test.priv.(*rsa.PrivateKey)
@@ -1545,7 +1545,7 @@ index 8846b00312..8734dd03c1 100644
  			SerialNumber: big.NewInt(1),
 @@ -3607,11 +3638,19 @@ func TestParseRevocationList(t *testing.T) {
  }
-
+ 
  func TestRevocationListCheckSignatureFrom(t *testing.T) {
 -	goodKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
 +	var testCurve elliptic.Curve
@@ -1572,7 +1572,7 @@ index 08452c7b1d..0732db0662 100644
 @@ -396,9 +396,11 @@ var depsRules = `
  	< crypto/internal/alias
  	< crypto/cipher;
-
+ 
 -	crypto/cipher,
 +	fmt, crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1580,15 +1580,15 @@ index 08452c7b1d..0732db0662 100644
 +	< github.com/golang-fips/openssl-fips/openssl
 +	< crypto/internal/backend
  	< crypto/boring;
-
+ 
  	crypto/internal/alias
 @@ -427,11 +429,13 @@ var depsRules = `
  	crypto/sha512
  	< CRYPTO;
-
+ 
 -	CGO, fmt, net !< CRYPTO;
 +	CGO, net !< CRYPTO;
-
+ 
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
 +	< github.com/golang-fips/openssl-fips/openssl/bbig
@@ -1599,14 +1599,14 @@ index 08452c7b1d..0732db0662 100644
  	< encoding/asn1
 @@ -629,6 +633,7 @@ func listStdPkgs(goroot string) ([]string, error) {
  }
-
+ 
  func TestDependencies(t *testing.T) {
 +	t.Skip("openssl-fips based toolchain has different dependencies than upstream")
  	if !testenv.HasSrc() {
  		// Tests run in a limited file system and we do not
  		// provide access to every source file.
 @@ -671,7 +676,7 @@ var buildIgnore = []byte("\n//go:build ignore")
-
+ 
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
 -	if strings.HasPrefix(pkg, "golang.org") {
@@ -1656,7 +1656,7 @@ index 780b481de8..63db9e9ed7 100644
 @@ -145,6 +150,29 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
  	return
  }
-
+ 
 +func findAddrInExecutableSection(t *testing.T, mmap []byte, m *profile.Mapping) uint64 {
 +	mappings := strings.Split(string(mmap), "\n")
 +	for _, mapping := range mappings {
@@ -1682,13 +1682,13 @@ index 780b481de8..63db9e9ed7 100644
 +
  func TestConvertCPUProfile(t *testing.T) {
  	addr1, addr2, map1, map2 := testPCs(t)
-
+ 
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253..dc25cdcfd5 100644
 --- a/src/runtime/runtime_boring.go
 +++ b/src/runtime/runtime_boring.go
 @@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
-
+ 
  //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
  func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
 +

--- a/patches/000-initial-setup.patch
+++ b/patches/000-initial-setup.patch
@@ -16,17 +16,17 @@ index 4aaf46b5d0..c231e299d9 100644
 --- a/src/cmd/go/testdata/script/gopath_std_vendor.txt
 +++ b/src/cmd/go/testdata/script/gopath_std_vendor.txt
 @@ -21,11 +21,11 @@ go build .
- 
+
  go list -deps -f '{{.ImportPath}} {{.Dir}}' .
  stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
 -! stdout $GOROOT[/\\]src[/\\]vendor
 +! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
- 
+
  go list -test -deps -f '{{.ImportPath}} {{.Dir}}' .
  stdout $GOPATH[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
 -! stdout $GOROOT[/\\]src[/\\]vendor
 +! stdout $GOROOT[/\\]src[/\\]vendor[/\\]golang.org[/\\]x[/\\]net[/\\]http2[/\\]hpack
- 
+
  -- issue16333/issue16333.go --
  package vendoring17
 diff --git a/src/crypto/ecdh/ecdh_test.go b/src/crypto/ecdh/ecdh_test.go
@@ -182,7 +182,7 @@ index 08a0903eb1..61a4662036 100644
  		t.Run(test.name, func(t *testing.T) {
  			t.Parallel()
 @@ -235,7 +246,11 @@ func TestVectors(t *testing.T) {
- 
+
  			switch curve {
  			case "P-224":
 -				pub.Curve = elliptic.P224()
@@ -206,10 +206,10 @@ index 53ac8504c2..4371e31b1a 100644
 +	"crypto/internal/backend/boringtest"
  	"testing"
  )
- 
+
 @@ -65,11 +67,13 @@ func testEqual(t *testing.T, c elliptic.Curve) {
  }
- 
+
  func TestEqual(t *testing.T) {
 -	t.Run("P224", func(t *testing.T) { testEqual(t, elliptic.P224()) })
 +	t.Run("P256", func(t *testing.T) { testEqual(t, elliptic.P256()) })
@@ -229,7 +229,7 @@ index 47c8698e2a..8b5c2cc9af 100644
 +++ b/src/crypto/ed25519/ed25519_test.go
 @@ -321,6 +321,7 @@ func TestMalleability(t *testing.T) {
  }
- 
+
  func TestAllocations(t *testing.T) {
 +	t.Skip("Allocations test broken with openssl linkage")
  	if boring.Enabled {
@@ -241,11 +241,11 @@ index f933f2800a..223ce04340 100644
 +++ b/src/crypto/ed25519/ed25519vectors_test.go
 @@ -72,6 +72,7 @@ func TestEd25519Vectors(t *testing.T) {
  }
- 
+
  func downloadEd25519Vectors(t *testing.T) []byte {
 +	t.Skip("skipping test that downloads external data")
  	testenv.MustHaveExternalNetwork(t)
- 
+
  	// Create a temp dir and modcache subdir.
 diff --git a/src/crypto/internal/backend/bbig/big.go b/src/crypto/internal/backend/bbig/big.go
 new file mode 100644
@@ -642,7 +642,7 @@ index dfa1eddc88..39a4fc184a 100644
  	"crypto/sha1"
 @@ -54,6 +56,10 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
- 
+
  func TestDecryptPKCS1v15(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -653,7 +653,7 @@ index dfa1eddc88..39a4fc184a 100644
  			return DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
 @@ -78,6 +84,10 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
- 
+
  func TestEncryptPKCS1v15(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -661,10 +661,10 @@ index dfa1eddc88..39a4fc184a 100644
 +
  	random := rand.Reader
  	k := (rsaPrivateKey.N.BitLen() + 7) / 8
- 
+
 @@ -139,6 +149,10 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
- 
+
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -675,7 +675,7 @@ index dfa1eddc88..39a4fc184a 100644
  		err := DecryptPKCS1v15SessionKey(nil, rsaPrivateKey, decodeBase64(test.in), key)
 @@ -153,6 +167,10 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
- 
+
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -691,21 +691,21 @@ index dfa1eddc88..39a4fc184a 100644
 -	{"Test.\n", "a4f3fa6ea93bcdd0c57be020c1193ecbfd6f200a3d95c409769b029578fa0e336ad9a347600e40d3ae823b8c7e6bad88cc07c1d54c3a1523cbbb6d58efc362ae"},
 +	{"Test.\n", "0c7c85d938862248846cba06b06ac9bfe752aafed3092c224f257855006aa35b43d101e6c8e59cbc4c20b07c81552963f189dea700e042d4b70c236a031a29a9273cc138e69dc1a5834491de4822d8cb6acf218789d2586cb0f3892236b0948ffaf8691f6fa04597caa45068f9be39b8ea8b5336a8c94e2696f872120778abcfea711e5fbf75f835f0f5204ccdd020013c2ceae25e9d1378a1d10cf86ca269eef48fee8ebb5e8dfb08f0c48d22d1a7162e080ec1f6e48541288aaaa1f2370f0688cf1786a32abed41df1d3b96b665794bf7a772743fc8b62d73901cea4569494c794a01ccc7dda0d42199f5b58739c0c0e280774b56ccf51993f5ea3d4954319"},
  }
- 
+
  func TestSignPKCS1v15(t *testing.T) {
 @@ -201,7 +219,7 @@ func TestSignPKCS1v15(t *testing.T) {
  		h.Write([]byte(test.in))
  		digest := h.Sum(nil)
- 
+
 -		s, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.SHA1, digest)
 +		s, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.SHA1, digest)
  		if err != nil {
  			t.Errorf("#%d %s", i, err)
  		}
 @@ -221,7 +239,7 @@ func TestVerifyPKCS1v15(t *testing.T) {
- 
+
  		sig, _ := hex.DecodeString(test.out)
- 
+
 -		err := VerifyPKCS1v15(&rsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
 +		err := VerifyPKCS1v15(&boringRsaPrivateKey.PublicKey, crypto.SHA1, digest, sig)
  		if err != nil {
@@ -717,7 +717,7 @@ index dfa1eddc88..39a4fc184a 100644
  	// file.
 -	expectedSig := decodeBase64("pX4DR8azytjdQ1rtUiC040FjkepuQut5q2ZFX1pTjBrOVKNjgsCDyiJDGZTCNoh9qpXYbhl7iEym30BWWwuiZg==")
 +	expectedSig := decodeBase64("XgDn6nJdfL/gY3eq15l9Va41/nNkDrkTlxOZYHYeFaMOW+Z4BHTCZ1LhqNBXOBK9XEyHho6okpY4rqE1zTIVX/kCGJ+jS6VRgUsHcTcpvKBYZCW84yrjE360gkntzkGxUF9FaiOGzmJKwBm1UvFgFIaYlvF+PdU0H1trBvm/RYRU42xOQRY1U+MSXgruFfINE20vPTlAG22uJ2CELrZUDykQGnrDFsEP0UqyyyiqGqxHt8E7iNYC6+xhPPC/ato9Bev08nu/U/EGH2imifSoNz/IN6h3fQClHwk1a74bPrcRsmUAAHOX2X1VKxK7IruinU8iOyoG6oFuvT+QlMnWAw==")
- 
+
 -	sig, err := SignPKCS1v15(nil, rsaPrivateKey, crypto.Hash(0), msg)
 +	sig, err := SignPKCS1v15(nil, boringRsaPrivateKey, crypto.Hash(0), msg)
  	if err != nil {
@@ -731,7 +731,7 @@ index dfa1eddc88..39a4fc184a 100644
  		t.Fatalf("signature failed to verify: %s", err)
  	}
  }
- 
+
  func TestShortSessionKey(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
@@ -743,7 +743,7 @@ index dfa1eddc88..39a4fc184a 100644
 @@ -297,6 +319,35 @@ func parsePublicKey(s string) *PublicKey {
  	return k
  }
- 
+
 +
 +var boringRsaPrivateKey = parseKey(testingKey(`-----BEGIN RSA TESTING KEY-----
 +MIIEogIBAAKCAQEAp5qgUIj096pw8U+AjcJucLWenR3oe+tEthXiAuqcYgslW5UU
@@ -813,11 +813,11 @@ index cf03e3cb7e..1226149321 100644
 @@ -195,10 +204,15 @@ func TestPSSNilOpts(t *testing.T) {
  	h.Write([]byte("testing"))
  	hashed := h.Sum(nil)
- 
+
 +	// Shouldn't this check return value?
  	SignPSS(rand.Reader, rsaPrivateKey, hash, hashed, nil)
  }
- 
+
  func TestPSSSigning(t *testing.T) {
 +	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +		t.Skip("skipping PSS test with BoringCrypto: too short key")
@@ -829,7 +829,7 @@ index cf03e3cb7e..1226149321 100644
 @@ -236,11 +250,15 @@ func TestPSSSigning(t *testing.T) {
  	}
  }
- 
+
 -func TestPSS513(t *testing.T) {
 +// This previously tested PSSSaltLengthAuto
 +// We'll change the key here to 2048 bits to
@@ -852,7 +852,7 @@ index cf03e3cb7e..1226149321 100644
 +	}); err.Error() != InvalidSaltLenErr.Error() && !strings.Contains(err.Error(), "RSA_sign_pss_mgf1 failed") {
  		t.Fatalf("SignPSS unexpected error: got %v, want %v", err, InvalidSaltLenErr)
  	}
- 
+
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
 index 63bc8dad1a..ab56ccd1ed 100644
 --- a/src/crypto/rsa/rsa.go
@@ -865,7 +865,7 @@ index 63bc8dad1a..ab56ccd1ed 100644
 +		return boring.EncryptRSAOAEP(hash, bkey, msg, label)
  	}
  	boring.UnreachableExceptTests()
- 
+
 @@ -680,7 +680,7 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
  		if err != nil {
  			return nil, err
@@ -882,7 +882,7 @@ index 3278a7ff30..b994daec19 100644
 @@ -23,6 +23,8 @@ import (
  	"testing"
  )
- 
+
 +import "crypto/internal/backend/boringtest"
 +
  func TestKeyGeneration(t *testing.T) {
@@ -902,7 +902,7 @@ index 3278a7ff30..b994daec19 100644
 @@ -114,6 +120,35 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		t.Errorf("private exponent too large")
  	}
- 
+
 +	if boring.Enabled {
 +		// Cannot call encrypt/decrypt with raw RSA. PKCSv1.5
 +		// not supported in some configurations.  Test with
@@ -938,7 +938,7 @@ index 3278a7ff30..b994daec19 100644
 @@ -121,7 +156,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		return
  	}
- 
+
 -	dec, err := DecryptPKCS1v15(nil, priv, enc)
 +	dec, err := DecryptPKCS1v15(rand.Reader, priv, enc)
  	if err != nil {
@@ -963,7 +963,7 @@ index 3278a7ff30..b994daec19 100644
 +			continue
 +		}
  		public := PublicKey{N: n, E: test.e}
- 
+
  		for j, message := range test.msgs {
 @@ -652,6 +694,10 @@ func TestDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
@@ -979,13 +979,13 @@ index 3278a7ff30..b994daec19 100644
 @@ -695,6 +741,10 @@ func Test2DecryptOAEP(t *testing.T) {
  	sha1 := crypto.SHA1
  	sha256 := crypto.SHA256
- 
+
 +	if boring.Enabled && n.BitLen() < 2048 {
 +		t.Skipf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
 +	}
 +
  	out, err := priv.Decrypt(random, in, &OAEPOptions{MGFHash: sha1, Hash: sha256})
- 
+
  	if err != nil {
 @@ -710,6 +760,10 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
@@ -1003,12 +1003,12 @@ index 1827f76458..140b1a3dd8 100644
 --- a/src/crypto/tls/boring.go
 +++ b/src/crypto/tls/boring.go
 @@ -8,8 +8,15 @@ package tls
- 
+
  import (
  	"crypto/internal/boring/fipstls"
 +	boring "crypto/internal/backend"
  )
- 
+
 +func init() {
 +       if boring.Enabled && !boring.ExecutingTest() {
 +               fipstls.Force()
@@ -1019,14 +1019,14 @@ index 1827f76458..140b1a3dd8 100644
  func needFIPS() bool {
  	return fipstls.Required()
 @@ -17,14 +24,18 @@ func needFIPS() bool {
- 
+
  // fipsMinVersion replaces c.minVersion in FIPS-only mode.
  func fipsMinVersion(c *Config) uint16 {
 -	// FIPS requires TLS 1.2.
 +	// FIPS requires TLS 1.2 or later.
  	return VersionTLS12
  }
- 
+
  // fipsMaxVersion replaces c.maxVersion in FIPS-only mode.
  func fipsMaxVersion(c *Config) uint16 {
 -	// FIPS requires TLS 1.2.
@@ -1038,7 +1038,7 @@ index 1827f76458..140b1a3dd8 100644
 +		return VersionTLS12
 +	}
  }
- 
+
  // default defaultFIPSCurvePreferences is the FIPS-allowed curves,
 diff --git a/src/crypto/tls/boring_test.go b/src/crypto/tls/boring_test.go
 index ba68f355eb..7bfe3f9417 100644
@@ -1063,7 +1063,7 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		test("VersionTLS13", VersionTLS13, "")
 +	}
- 
+
  	fipstls.Force()
  	defer fipstls.Abandon()
 @@ -52,11 +58,13 @@ func TestBoringServerProtocolVersion(t *testing.T) {
@@ -1075,12 +1075,12 @@ index ba68f355eb..7bfe3f9417 100644
 +		test("VersionTLS13", VersionTLS13, "")
 +	}
  }
- 
+
  func isBoringVersion(v uint16) bool {
 -	return v == VersionTLS12
 +	return v == VersionTLS12 || (boring.SupportsHKDF() && v == VersionTLS13)
  }
- 
+
  func isBoringCipherSuite(id uint16) bool {
 @@ -66,7 +74,9 @@ func isBoringCipherSuite(id uint16) bool {
  		TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -1096,7 +1096,7 @@ index ba68f355eb..7bfe3f9417 100644
 @@ -226,7 +236,14 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
  			// 1.3, and the ECDSA ones bind to the curve used.
  			serverConfig.MaxVersion = VersionTLS12
- 
+
 -			clientErr, serverErr := boringHandshake(t, testConfig, serverConfig)
 +			clientConfig := testConfig.Clone()
 +
@@ -1111,7 +1111,7 @@ index ba68f355eb..7bfe3f9417 100644
  			}
 @@ -315,15 +332,31 @@ func TestBoringCertAlgs(t *testing.T) {
  	R2 := boringCert(t, "R2", boringRSAKey(t, 512), nil, boringCertCA)
- 
+
  	M1_R1 := boringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
 -	M2_R1 := boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
 +
@@ -1123,13 +1123,13 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		M2_R1 = boringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
 +	}
- 
+
  	I_R1 := boringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
 -	I_R2 := boringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 +	I_R2 := boringCert(t, "I_R2", I_R1.key, R2, boringCertCA)
  	I_M1 := boringCert(t, "I_M1", I_R1.key, M1_R1, boringCertCA|boringCertFIPSOK)
  	I_M2 := boringCert(t, "I_M2", I_R1.key, M2_R1, boringCertCA|boringCertFIPSOK)
- 
+
  	L1_I := boringCert(t, "L1_I", boringECDSAKey(t, elliptic.P384()), I_R1, boringCertLeaf|boringCertFIPSOK)
 -	L2_I := boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf)
 +
@@ -1141,20 +1141,20 @@ index ba68f355eb..7bfe3f9417 100644
 +	} else {
 +		L2_I = boringCert(t, "L2_I", boringRSAKey(t, 1024), I_R1, boringCertLeaf|boringCertNotBoring)
 +	}
- 
+
  	// client verifying server cert
  	testServerCert := func(t *testing.T, desc string, pool *x509.CertPool, key interface{}, list [][]byte, ok bool) {
 @@ -336,6 +369,11 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig.Certificates = []Certificate{{Certificate: list, PrivateKey: key}}
  		serverConfig.BuildNameToCertificate()
- 
+
 +		if boring.Enabled {
 +			serverConfig.Rand = boring.RandReader
 +			clientConfig.Rand = boring.RandReader
 +		}
 +
  		clientErr, _ := boringHandshake(t, clientConfig, serverConfig)
- 
+
  		if (clientErr == nil) == ok {
 @@ -362,6 +400,16 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig := testConfig.Clone()
@@ -1170,9 +1170,9 @@ index ba68f355eb..7bfe3f9417 100644
 +			serverConfig.Rand = boring.RandReader
 +			clientConfig.Rand = boring.RandReader
 +		}
- 
+
  		_, serverErr := boringHandshake(t, clientConfig, serverConfig)
- 
+
 @@ -384,8 +432,8 @@ func TestBoringCertAlgs(t *testing.T) {
  	// exhaustive test with computed answers.
  	r1pool := x509.NewCertPool()
@@ -1217,7 +1217,7 @@ index ba68f355eb..7bfe3f9417 100644
  	boringCertFIPSOK = 0x80
 +	boringCertNotBoring = 0x100
  )
- 
+
  func boringRSAKey(t *testing.T, size int) *rsa.PrivateKey {
 @@ -490,6 +539,7 @@ type boringCertificate struct {
  	cert      *x509.Certificate
@@ -1225,7 +1225,7 @@ index ba68f355eb..7bfe3f9417 100644
  	fipsOK    bool
 +	notBoring bool
  }
- 
+
  func boringCert(t *testing.T, name string, key interface{}, parent *boringCertificate, mode int) *boringCertificate {
 @@ -511,7 +561,7 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
@@ -1238,13 +1238,13 @@ index ba68f355eb..7bfe3f9417 100644
  		tmpl.IsCA = true
 @@ -548,7 +598,8 @@ func boringCert(t *testing.T, name string, key interface{}, parent *boringCertif
  	}
- 
+
  	fipsOK := mode&boringCertFIPSOK != 0
 -	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK}
 +	notBoring := mode&boringCertNotBoring != 0
 +	return &boringCertificate{name, org, parentOrg, der, cert, key, fipsOK, notBoring}
  }
- 
+
  // A self-signed test certificate with an RSA key of size 2048, for testing
 diff --git a/src/crypto/tls/cipher_suites.go b/src/crypto/tls/cipher_suites.go
 index 04e6dfe018..b6ed936cd1 100644
@@ -1253,7 +1253,7 @@ index 04e6dfe018..b6ed936cd1 100644
 @@ -354,6 +354,11 @@ var defaultCipherSuitesTLS13NoAES = []uint16{
  	TLS_AES_256_GCM_SHA384,
  }
- 
+
 +var defaultFIPSCipherSuitesTLS13 = []uint16{
 +	TLS_AES_128_GCM_SHA256,
 +	TLS_AES_256_GCM_SHA384,
@@ -1289,7 +1289,7 @@ index 63d86b9f3a..a8ee915041 100644
 --- a/src/crypto/tls/handshake_client.go
 +++ b/src/crypto/tls/handshake_client.go
 @@ -127,7 +127,9 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, *ecdh.PrivateKey, error) {
- 
+
  	var key *ecdh.PrivateKey
  	if hello.supportedVersions[0] == VersionTLS13 {
 -		if hasAESGCMHardwareSupport {
@@ -1305,12 +1305,12 @@ index 22be38faff..d460eeb880 100644
 +++ b/src/crypto/tls/handshake_client_test.go
 @@ -2156,6 +2156,7 @@ func testBuffering(t *testing.T, version uint16) {
  }
- 
+
  func TestAlertFlushing(t *testing.T) {
 +       t.Skip("unsupported in FIPS mode, different error returned")
  	c, s := localPipe(t)
  	done := make(chan bool)
- 
+
 diff --git a/src/crypto/tls/handshake_client_tls13.go b/src/crypto/tls/handshake_client_tls13.go
 index 4a8661085e..87fe11de5c 100644
 --- a/src/crypto/tls/handshake_client_tls13.go
@@ -1318,7 +1318,7 @@ index 4a8661085e..87fe11de5c 100644
 @@ -41,10 +41,6 @@ type clientHandshakeStateTLS13 struct {
  func (hs *clientHandshakeStateTLS13) handshake() error {
  	c := hs.c
- 
+
 -	if needFIPS() {
 -		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
 -	}
@@ -1333,7 +1333,7 @@ index b7b568cd84..af75e7dbe0 100644
 @@ -44,10 +44,6 @@ type serverHandshakeStateTLS13 struct {
  func (hs *serverHandshakeStateTLS13) handshake() error {
  	c := hs.c
- 
+
 -	if needFIPS() {
 -		return errors.New("tls: internal error: TLS 1.3 reached in FIPS mode")
 -	}
@@ -1392,7 +1392,7 @@ index ae8f80a7cf..30a8450f40 100644
 +		return hkdf.Extract(c.hash.New, newSecret, currentSecret)
 +	}
  }
- 
+
  // nextTrafficSecret generates the next traffic secret, given the current one,
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
 index 33fd0ed52b..102acda578 100644
@@ -1408,7 +1408,7 @@ index 33fd0ed52b..102acda578 100644
  	"crypto/x509/pkix"
 @@ -58,7 +59,15 @@ func TestBoringAllowCert(t *testing.T) {
  	R3 := testBoringCert(t, "R3", boringRSAKey(t, 4096), nil, boringCertCA|boringCertFIPSOK)
- 
+
  	M1_R1 := testBoringCert(t, "M1_R1", boringECDSAKey(t, elliptic.P256()), R1, boringCertCA|boringCertFIPSOK)
 -	M2_R1 := testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P224()), R1, boringCertCA)
 +
@@ -1420,7 +1420,7 @@ index 33fd0ed52b..102acda578 100644
 +	} else {
 +		M2_R1 = testBoringCert(t, "M2_R1", boringECDSAKey(t, elliptic.P384()), R1, boringCertCA|boringCertFIPSOK)
 +	}
- 
+
  	I_R1 := testBoringCert(t, "I_R1", boringRSAKey(t, 3072), R1, boringCertCA|boringCertFIPSOK)
  	testBoringCert(t, "I_R2", I_R1.key, R2, boringCertCA|boringCertFIPSOK)
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
@@ -1439,7 +1439,7 @@ index 8846b00312..8734dd03c1 100644
 @@ -125,32 +127,54 @@ func TestParsePKIXPublicKey(t *testing.T) {
  	})
  }
- 
+
 +// This public key is extracted from pemPrivateKey defined below with
 +// the following command:
 +//
@@ -1462,7 +1462,7 @@ index 8846b00312..8734dd03c1 100644
 +aQIDAQAB
  -----END PUBLIC KEY-----
  `
- 
+
 +// This key is generated with the following command:
 +//
 +//   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out key.pem
@@ -1510,9 +1510,9 @@ index 8846b00312..8734dd03c1 100644
 +QOhL8wXZcdwHKsONy55kZHo8pmneqi9EnqqLGguLwx5WIMzWvZ8=
  -----END RSA TESTING KEY-----
  `)
- 
+
 @@ -210,13 +234,13 @@ func bigFromHexString(s string) *big.Int {
- 
+
  var rsaPrivateKey = &rsa.PrivateKey{
  	PublicKey: rsa.PublicKey{
 -		N: bigFromString("124737666279038955318614287965056875799409043964547386061640914307192830334599556034328900586693254156136128122194531292927142396093148164407300419162827624945636708870992355233833321488652786796134504707628792159725681555822420087112284637501705261187690946267527866880072856272532711620639179596808018872997"),
@@ -1528,10 +1528,10 @@ index 8846b00312..8734dd03c1 100644
 +		bigFromString("146306182837940795154243491672545598732731521261772425577071902398494756400761181229877966908959767779942799478853764354255505873530749881845000716071915494302715554511619294255599209521952152229250381623079574375248555498847701822870266575429060940749806104053368129657146195126647000200158517816035847077797"),
  	},
  }
- 
+
 @@ -629,6 +653,13 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
- 
+
  	for _, test := range tests {
 +		if boring.Enabled && test.sigAlgo.isRSAPSS() {
 +			key, _ := test.priv.(*rsa.PrivateKey)
@@ -1545,7 +1545,7 @@ index 8846b00312..8734dd03c1 100644
  			SerialNumber: big.NewInt(1),
 @@ -3607,11 +3638,19 @@ func TestParseRevocationList(t *testing.T) {
  }
- 
+
  func TestRevocationListCheckSignatureFrom(t *testing.T) {
 -	goodKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
 +	var testCurve elliptic.Curve
@@ -1572,7 +1572,7 @@ index 08452c7b1d..0732db0662 100644
 @@ -396,9 +396,11 @@ var depsRules = `
  	< crypto/internal/alias
  	< crypto/cipher;
- 
+
 -	crypto/cipher,
 +	fmt, crypto/cipher,
  	crypto/internal/boring/bcache
@@ -1580,15 +1580,15 @@ index 08452c7b1d..0732db0662 100644
 +	< github.com/golang-fips/openssl-fips/openssl
 +	< crypto/internal/backend
  	< crypto/boring;
- 
+
  	crypto/internal/alias
 @@ -427,11 +429,13 @@ var depsRules = `
  	crypto/sha512
  	< CRYPTO;
- 
+
 -	CGO, fmt, net !< CRYPTO;
 +	CGO, net !< CRYPTO;
- 
+
  	# CRYPTO-MATH is core bignum-based crypto - no cgo, net; fmt now ok.
  	CRYPTO, FMT, math/big
 +	< github.com/golang-fips/openssl-fips/openssl/bbig
@@ -1599,14 +1599,14 @@ index 08452c7b1d..0732db0662 100644
  	< encoding/asn1
 @@ -629,6 +633,7 @@ func listStdPkgs(goroot string) ([]string, error) {
  }
- 
+
  func TestDependencies(t *testing.T) {
 +	t.Skip("openssl-fips based toolchain has different dependencies than upstream")
  	if !testenv.HasSrc() {
  		// Tests run in a limited file system and we do not
  		// provide access to every source file.
 @@ -671,7 +676,7 @@ var buildIgnore = []byte("\n//go:build ignore")
- 
+
  func findImports(pkg string) ([]string, error) {
  	vpkg := pkg
 -	if strings.HasPrefix(pkg, "golang.org") {
@@ -1656,7 +1656,7 @@ index 780b481de8..63db9e9ed7 100644
 @@ -145,6 +150,29 @@ func testPCs(t *testing.T) (addr1, addr2 uint64, map1, map2 *profile.Mapping) {
  	return
  }
- 
+
 +func findAddrInExecutableSection(t *testing.T, mmap []byte, m *profile.Mapping) uint64 {
 +	mappings := strings.Split(string(mmap), "\n")
 +	for _, mapping := range mappings {
@@ -1682,13 +1682,13 @@ index 780b481de8..63db9e9ed7 100644
 +
  func TestConvertCPUProfile(t *testing.T) {
  	addr1, addr2, map1, map2 := testPCs(t)
- 
+
 diff --git a/src/runtime/runtime_boring.go b/src/runtime/runtime_boring.go
 index 5a98b20253..dc25cdcfd5 100644
 --- a/src/runtime/runtime_boring.go
 +++ b/src/runtime/runtime_boring.go
 @@ -17,3 +17,8 @@ func boring_runtime_arg0() string {
- 
+
  //go:linkname fipstls_runtime_arg0 crypto/internal/boring/fipstls.runtime_arg0
  func fipstls_runtime_arg0() string { return boring_runtime_arg0() }
 +

--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -5,15 +5,15 @@ index a9ec6e6bfe..7111867b66 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package api
-
+ 
 @@ -12,6 +12,6 @@ import (
  )
-
+ 
  func init() {
 -	fmt.Printf("SKIP with boringcrypto enabled\n")
 +	fmt.Printf("SKIP with !no_openssl enabled\n")
@@ -31,7 +31,7 @@ index 183c1697c8..abe85b5ad3 100644
 +	boring "crypto/internal/backend"
  	"strconv"
  )
-
+ 
 @@ -38,7 +38,7 @@ func NewCipher(key []byte) (cipher.Block, error) {
  	case 16, 24, 32:
  		break
@@ -61,10 +61,10 @@ index 097c37e343..47618fe3c6 100644
 @@ -13,9 +13,9 @@
  // is satisfied, so that applications can tag files that use this package.
  package boring
-
+ 
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
-
+ 
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
 -	return boring.Enabled
@@ -123,7 +123,7 @@ index 74420559b5..acf71ba580 100644
 --- a/src/crypto/ecdh/ecdh.go
 +++ b/src/crypto/ecdh/ecdh.go
 @@ -8,7 +8,7 @@ package ecdh
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -190,7 +190,7 @@ index 01354fa2cf..a7f1d9eced 100644
 +++ b/src/crypto/ecdh/nist.go
 @@ -5,7 +5,7 @@
  package ecdh
-
+ 
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -199,7 +199,7 @@ index 01354fa2cf..a7f1d9eced 100644
  	"encoding/binary"
 @@ -36,7 +36,7 @@ func (c *nistCurve[Point]) String() string {
  var errInvalidPrivateKey = errors.New("crypto/ecdh: invalid private key")
-
+ 
  func (c *nistCurve[Point]) GenerateKey(rand io.Reader) (*PrivateKey, error) {
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
@@ -227,12 +227,12 @@ index 01354fa2cf..a7f1d9eced 100644
 @@ -196,7 +196,7 @@ func (c *nistCurve[Point]) ecdh(local *PrivateKey, remote *PublicKey) ([]byte, e
  	// only be the result of a scalar multiplication if one of the inputs is the
  	// zero scalar or the point at infinity.
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		return boring.ECDH(local.boring, remote.boring)
  	}
-
+ 
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 275c60b4de..58f0034b18 100644
 --- a/src/crypto/ecdsa/boring.go
@@ -240,12 +240,12 @@ index 275c60b4de..58f0034b18 100644
 @@ -2,13 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package ecdsa
-
+ 
  import (
 -	"crypto/internal/boring"
 -	"crypto/internal/boring/bbig"
@@ -255,7 +255,7 @@ index 275c60b4de..58f0034b18 100644
  	"math/big"
  )
 diff --git a/src/crypto/ecdsa/ecdsa.go b/src/crypto/ecdsa/ecdsa.go
-index 68272af41f..b1eea00bef 100644
+index 03a9a72ddd..4bf497f9cc 100644
 --- a/src/crypto/ecdsa/ecdsa.go
 +++ b/src/crypto/ecdsa/ecdsa.go
 @@ -27,8 +27,8 @@ import (
@@ -272,7 +272,7 @@ index 68272af41f..b1eea00bef 100644
 @@ -154,7 +154,7 @@ func (priv *PrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOp
  func GenerateKey(c elliptic.Curve, rand io.Reader) (*PrivateKey, error) {
  	randutil.MaybeReadByte(rand)
-
+ 
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
  		x, y, d, err := boring.GenerateKeyECDSA(c.Params().Name)
@@ -281,7 +281,7 @@ index 68272af41f..b1eea00bef 100644
 @@ -248,7 +248,7 @@ var errNoAsm = errors.New("no assembly implementation available")
  func SignASN1(rand io.Reader, priv *PrivateKey, hash []byte) ([]byte, error) {
  	randutil.MaybeReadByte(rand)
-
+ 
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
  		b, err := boringPrivateKey(priv)
@@ -301,7 +301,7 @@ index 37f3a18223..51e3b49cdc 100644
 --- a/src/crypto/ecdsa/ecdsa_hashsignverify.go
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify.go
 @@ -2,7 +2,7 @@ package ecdsa
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -312,7 +312,7 @@ index 37f3a18223..51e3b49cdc 100644
 @@ -11,7 +11,7 @@ import (
  func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) (*big.Int, *big.Int, error) {
  	randutil.MaybeReadByte(rand)
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		b, err := boringPrivateKey(priv)
@@ -320,7 +320,7 @@ index 37f3a18223..51e3b49cdc 100644
  			return nil, nil, err
 @@ -28,7 +28,7 @@ func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) (*big
  }
-
+ 
  func HashVerify(pub *PublicKey, msg []byte, r, s *big.Int, h crypto.Hash) bool {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -332,7 +332,7 @@ index d12ba2f441..6334a56496 100644
 --- a/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 @@ -2,7 +2,7 @@ package ecdsa
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -343,14 +343,14 @@ index d12ba2f441..6334a56496 100644
 @@ -34,7 +34,7 @@ func testHashSignAndHashVerify(t *testing.T, c elliptic.Curve, tag string) {
  func TestHashSignAndHashVerify(t *testing.T) {
  	testHashSignAndHashVerify(t, elliptic.P256(), "p256")
-
+ 
 -	if testing.Short() && !boring.Enabled {
 +	if testing.Short() && !boring.Enabled() {
  		return
  	}
  	testHashSignAndHashVerify(t, elliptic.P384(), "p384")
 diff --git a/src/crypto/ecdsa/ecdsa_test.go b/src/crypto/ecdsa/ecdsa_test.go
-index 51f58b305e..967e8ff7fb 100644
+index 61a4662036..80e484842b 100644
 --- a/src/crypto/ecdsa/ecdsa_test.go
 +++ b/src/crypto/ecdsa/ecdsa_test.go
 @@ -10,7 +10,7 @@ import (
@@ -359,10 +359,10 @@ index 51f58b305e..967e8ff7fb 100644
  	"crypto/internal/backend/boringtest"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
+ 	"crypto/internal/bigmod"
  	"crypto/rand"
  	"crypto/sha1"
- 	"crypto/sha256"
-@@ -37,7 +37,7 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+@@ -38,7 +38,7 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
  	}
  	if testing.Short() {
  		tests = tests[:1]
@@ -371,7 +371,7 @@ index 51f58b305e..967e8ff7fb 100644
  		p224 := struct {
  			name  string
  			curve elliptic.Curve
-@@ -45,7 +45,7 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
+@@ -46,7 +46,7 @@ func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {
  		tests = append(tests, p224)
  	}
  	for _, test := range tests {
@@ -380,8 +380,8 @@ index 51f58b305e..967e8ff7fb 100644
  			t.Skip("unsupported test in FIPS mode")
  		}
  		curve := test.curve
-@@ -245,7 +245,7 @@ func TestVectors(t *testing.T) {
-
+@@ -246,7 +246,7 @@ func TestVectors(t *testing.T) {
+ 
  			switch curve {
  			case "P-224":
 -				if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
@@ -418,15 +418,15 @@ index 039bd82ed2..21a35b760c 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build !boringcrypto
 +//go:build no_openssl
-
+ 
  package ecdsa
-
+ 
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
-
+ 
  func boringPublicKey(*PublicKey) (*boring.PublicKeyECDSA, error) {
 -	panic("boringcrypto: not available")
 +	panic("!no_openssl: not available")
@@ -449,7 +449,7 @@ index 8b5c2cc9af..ebbb1c0c07 100644
  	"crypto/sha512"
  	"encoding/hex"
 @@ -322,7 +322,7 @@ func TestMalleability(t *testing.T) {
-
+ 
  func TestAllocations(t *testing.T) {
  	t.Skip("Allocations test broken with openssl linkage")
 -	if boring.Enabled {
@@ -463,7 +463,7 @@ index ed3ebc0602..9941228156 100644
 +++ b/src/crypto/hmac/hmac.go
 @@ -22,7 +22,7 @@ timing side-channels:
  package hmac
-
+ 
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -484,7 +484,7 @@ index 55415abf02..0edd7a6003 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
 @@ -6,7 +6,7 @@ package hmac
-
+ 
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -494,7 +494,7 @@ index 55415abf02..0edd7a6003 100644
  	"crypto/sha256"
 @@ -584,8 +584,8 @@ func TestHMAC(t *testing.T) {
  }
-
+ 
  func TestNonUniqueHash(t *testing.T) {
 -	if boring.Enabled {
 -		t.Skip("hash.Hash provided by boringcrypto are not comparable")
@@ -1367,10 +1367,10 @@ index f2e5a503ea..65918a480e 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
@@ -1380,23 +1380,23 @@ index 3bf1471fb0..d6c5ca736d 100644
 @@ -2,10 +2,10 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
 -// This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 +// This package only exists with GOEXPERIMENT=!no_openssl, but the effects are independent
  // of the use of BoringCrypto.
  package fipstls
-
+ 
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
 index 40fce36314..c30be35635 100644
 --- a/src/crypto/rand/rand_unix.go
 +++ b/src/crypto/rand/rand_unix.go
 @@ -10,7 +10,7 @@
  package rand
-
+ 
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -1405,7 +1405,7 @@ index 40fce36314..c30be35635 100644
  	"os"
 @@ -23,7 +23,7 @@ import (
  const urandomDevice = "/dev/urandom"
-
+ 
  func init() {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1419,12 +1419,12 @@ index b9f9d3154f..85c2a45848 100644
 @@ -2,13 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package rsa
-
+ 
  import (
 -	"crypto/internal/boring"
 -	"crypto/internal/boring/bbig"
@@ -1440,10 +1440,10 @@ index 2234d079f0..4e7fd9de4a 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
@@ -1453,15 +1453,15 @@ index 2abc043640..a83be6dfdb 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build !boringcrypto
 +//go:build no_openssl
-
+ 
  package rsa
-
+ 
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
-
+ 
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
 -	panic("boringcrypto: not available")
 +	panic("!no_openssl: not available")
@@ -1475,7 +1475,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -6,7 +6,7 @@ package rsa
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1486,7 +1486,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -46,7 +46,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  		return nil, ErrMessageTooLong
  	}
-
+ 
 -	if boring.Enabled && random == boring.RandReader {
 +	if boring.Enabled() && random == boring.RandReader {
  		bkey, err := boringPublicKey(pub)
@@ -1495,7 +1495,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -66,7 +66,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  	em[len(em)-len(msg)-1] = 0
  	copy(mm, msg)
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PublicKeyRSA
@@ -1504,7 +1504,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -91,7 +91,7 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
  		return nil, err
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1513,7 +1513,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -170,7 +170,7 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
  		return
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PrivateKeyRSA
@@ -1522,7 +1522,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -278,12 +278,12 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
  		return nil, ErrMessageTooLong
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1532,7 +1532,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 -		return boring.SignRSAPKCS1v15(bkey, hash, hashed)
 +		return boring.SignRSAPKCS1v15(bkey, hash, hashed, true)
  	}
-
+ 
  	// EM = 0x00 || 0x01 || PS || 0x00 || T
 @@ -304,12 +304,12 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
  // returning a nil error. If hash is zero then hashed is used directly. This
@@ -1564,49 +1564,49 @@ index 39a4fc184a..0853178e3a 100644
  	. "crypto/rsa"
 @@ -56,7 +56,7 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
-
+ 
  func TestDecryptPKCS1v15(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
-
+ 
 @@ -84,7 +84,7 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
-
+ 
  func TestEncryptPKCS1v15(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
-
+ 
 @@ -149,7 +149,7 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
-
+ 
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
-
+ 
 @@ -167,7 +167,7 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
-
+ 
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
-
+ 
 @@ -277,7 +277,7 @@ func TestUnpaddedSignature(t *testing.T) {
  }
-
+ 
  func TestShortSessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
-
+ 
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
 index f7d23b55ef..3c822aa587 100644
 --- a/src/crypto/rsa/pss.go
@@ -1623,7 +1623,7 @@ index f7d23b55ef..3c822aa587 100644
 @@ -214,7 +214,7 @@ func signPSSWithSalt(priv *PrivateKey, hash crypto.Hash, hashed, salt []byte) ([
  		return nil, err
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1668,16 +1668,16 @@ index 1226149321..befd1612b5 100644
 +	if boring.Enabled() {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
-
+ 
 @@ -209,7 +209,7 @@ func TestPSSNilOpts(t *testing.T) {
  }
-
+ 
  func TestPSSSigning(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +	if boring.Enabled() && !boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
-
+ 
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
 index ab56ccd1ed..dd79dc5439 100644
 --- a/src/crypto/rsa/rsa.go
@@ -1696,7 +1696,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -286,7 +286,7 @@ func GenerateKey(random io.Reader, bits int) (*PrivateKey, error) {
  func GenerateMultiPrimeKey(random io.Reader, nprimes int, bits int) (*PrivateKey, error) {
  	randutil.MaybeReadByte(random)
-
+ 
 -	if boring.Enabled && random == boring.RandReader && nprimes == 2 &&
 +	if boring.Enabled() && random == boring.RandReader && nprimes == 2 &&
  		(bits == 2048 || bits == 3072 || bits == 4096) {
@@ -1705,7 +1705,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -504,7 +504,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
  		return nil, ErrMessageTooLong
  	}
-
+ 
 -	if boring.Enabled && random == boring.RandReader {
 +	if boring.Enabled() && random == boring.RandReader {
  		bkey, err := boringPublicKey(pub)
@@ -1714,7 +1714,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -533,7 +533,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
  	mgf1XOR(db, hash, seed)
  	mgf1XOR(seed, hash, db)
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PublicKeyRSA
@@ -1723,7 +1723,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -675,7 +675,7 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
  		return nil, ErrDecryption
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1754,7 +1754,7 @@ index b994daec19..4b7427e1ae 100644
 @@ -120,12 +120,12 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		t.Errorf("private exponent too large")
  	}
-
+ 
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		// Cannot call encrypt/decrypt with raw RSA. PKCSv1.5
@@ -1768,7 +1768,7 @@ index b994daec19..4b7427e1ae 100644
  		}
 @@ -167,7 +167,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  }
-
+ 
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1805,12 +1805,12 @@ index b994daec19..4b7427e1ae 100644
 @@ -741,7 +741,7 @@ func Test2DecryptOAEP(t *testing.T) {
  	sha1 := crypto.SHA1
  	sha256 := crypto.SHA256
-
+ 
 -	if boring.Enabled && n.BitLen() < 2048 {
 +	if boring.Enabled() && n.BitLen() < 2048 {
  		t.Skipf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
  	}
-
+ 
 @@ -760,7 +760,7 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
@@ -1826,18 +1826,18 @@ index b5786d1bf4..9bd03f3940 100644
 +++ b/src/crypto/sha1/boring.go
 @@ -12,11 +12,11 @@
  package sha1
-
+ 
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
  	"hash"
  )
-
+ 
 -const boringEnabled = boring.Enabled
 +var boringEnabled = boring.Enabled()
-
+ 
  func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
-
+ 
 diff --git a/src/crypto/sha1/notboring.go b/src/crypto/sha1/notboring.go
 index 42ef87937f..c1a3205539 100644
 --- a/src/crypto/sha1/notboring.go
@@ -1845,15 +1845,15 @@ index 42ef87937f..c1a3205539 100644
 @@ -11,10 +11,10 @@ import (
  	"hash"
  )
-
+ 
 -const boringEnabled = false
 +var boringEnabled = false
-
+ 
 -func boringNewSHA1() hash.Hash { panic("boringcrypto: not available") }
 +func boringNewSHA1() hash.Hash { panic("!no_openssl: not available") }
-
+ 
  func boringUnreachable() {}
-
+ 
 -func boringSHA1([]byte) [20]byte { panic("boringcrypto: not available") }
 +func boringSHA1([]byte) [20]byte { panic("!no_openssl: not available") }
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
@@ -1861,7 +1861,7 @@ index 85ed126091..71f4b46663 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -8,7 +8,7 @@ package sha1
-
+ 
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -1879,7 +1879,7 @@ index 85ed126091..71f4b46663 100644
  				}
  				io.WriteString(c, g.in[0:len(g.in)/2])
 @@ -145,7 +145,7 @@ func TestBlockSize(t *testing.T) {
-
+ 
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -1889,7 +1889,7 @@ index 85ed126091..71f4b46663 100644
  	for i := 1; i < 30; i++ { // arbitrary factor
 @@ -218,7 +218,7 @@ func TestLargeHashes(t *testing.T) {
  }
-
+ 
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1901,7 +1901,7 @@ index 2deafbc9fc..282c326b32 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -8,7 +8,7 @@ package sha256
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1919,7 +1919,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	d := new(digest)
 @@ -158,7 +158,7 @@ func New() hash.Hash {
-
+ 
  // New224 returns a new hash.Hash computing the SHA224 checksum.
  func New224() hash.Hash {
 -	if boring.Enabled {
@@ -1928,7 +1928,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	d := new(digest)
 @@ -251,7 +251,7 @@ func (d *digest) checkSum() [Size]byte {
-
+ 
  // Sum256 returns the SHA256 checksum of the data.
  func Sum256(data []byte) [Size]byte {
 -	if boring.Enabled {
@@ -1937,7 +1937,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	var d digest
 @@ -262,7 +262,7 @@ func Sum256(data []byte) [Size]byte {
-
+ 
  // Sum224 returns the SHA224 checksum of the data.
  func Sum224(data []byte) [Size224]byte {
 -	if boring.Enabled {
@@ -1950,7 +1950,7 @@ index 7304678346..a073d31119 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
-
+ 
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -1959,7 +1959,7 @@ index 7304678346..a073d31119 100644
  	"encoding"
  	"fmt"
 @@ -217,7 +217,7 @@ func TestBlockSize(t *testing.T) {
-
+ 
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -1969,7 +1969,7 @@ index 7304678346..a073d31119 100644
  	gen, asm := New().(*digest), New().(*digest)
 @@ -294,7 +294,7 @@ func TestLargeHashes(t *testing.T) {
  }
-
+ 
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1981,7 +1981,7 @@ index 9ae1b3aae2..e56eedb201 100644
 --- a/src/crypto/sha512/sha512.go
 +++ b/src/crypto/sha512/sha512.go
 @@ -12,7 +12,7 @@ package sha512
-
+ 
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1990,7 +1990,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	"errors"
  	"hash"
 @@ -206,7 +206,7 @@ func consumeUint64(b []byte) ([]byte, uint64) {
-
+ 
  // New returns a new hash.Hash computing the SHA-512 checksum.
  func New() hash.Hash {
 -	if boring.Enabled {
@@ -1999,7 +1999,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := &digest{function: crypto.SHA512}
 @@ -230,7 +230,7 @@ func New512_256() hash.Hash {
-
+ 
  // New384 returns a new hash.Hash computing the SHA-384 checksum.
  func New384() hash.Hash {
 -	if boring.Enabled {
@@ -2008,7 +2008,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := &digest{function: crypto.SHA384}
 @@ -341,7 +341,7 @@ func (d *digest) checkSum() [Size]byte {
-
+ 
  // Sum512 returns the SHA512 checksum of the data.
  func Sum512(data []byte) [Size]byte {
 -	if boring.Enabled {
@@ -2017,7 +2017,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := digest{function: crypto.SHA512}
 @@ -352,7 +352,7 @@ func Sum512(data []byte) [Size]byte {
-
+ 
  // Sum384 returns the SHA384 checksum of the data.
  func Sum384(data []byte) [Size384]byte {
 -	if boring.Enabled {
@@ -2030,7 +2030,7 @@ index 921cdbb7bb..a35165bcbf 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512
-
+ 
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -2039,7 +2039,7 @@ index 921cdbb7bb..a35165bcbf 100644
  	"encoding"
  	"encoding/hex"
 @@ -823,7 +823,7 @@ func TestBlockSize(t *testing.T) {
-
+ 
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -2049,7 +2049,7 @@ index 921cdbb7bb..a35165bcbf 100644
  	gen, asm := New().(*digest), New().(*digest)
 @@ -893,7 +893,7 @@ func TestLargeHashes(t *testing.T) {
  }
-
+ 
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -2063,15 +2063,15 @@ index 140b1a3dd8..fe6fa96d28 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package tls
-
+ 
 @@ -12,7 +12,7 @@ import (
  )
-
+ 
  func init() {
 -       if boring.Enabled && !boring.ExecutingTest() {
 +       if boring.Enabled() && !boring.ExecutingTest() {
@@ -2085,12 +2085,12 @@ index 7bfe3f9417..49702f59ba 100644
 @@ -2,14 +2,14 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package tls
-
+ 
  import (
  	"crypto/ecdsa"
  	"crypto/elliptic"
@@ -2109,9 +2109,9 @@ index 7bfe3f9417..49702f59ba 100644
  	} else {
  		test("VersionTLS13", VersionTLS13, "")
 @@ -238,7 +238,7 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
-
+ 
  			clientConfig := testConfig.Clone()
-
+ 
 -			if boring.Enabled {
 +			if boring.Enabled() {
  				serverConfig.Rand = boring.RandReader
@@ -2120,7 +2120,7 @@ index 7bfe3f9417..49702f59ba 100644
 @@ -369,7 +369,7 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig.Certificates = []Certificate{{Certificate: list, PrivateKey: key}}
  		serverConfig.BuildNameToCertificate()
-
+ 
 -		if boring.Enabled {
 +		if boring.Enabled() {
  			serverConfig.Rand = boring.RandReader
@@ -2136,7 +2136,7 @@ index 7bfe3f9417..49702f59ba 100644
  			serverConfig.Certificates[0].PrivateKey = testRSA2048PrivateKey
  			serverConfig.BuildNameToCertificate()
  		}
-
+ 
 -		if boring.Enabled {
 +		if boring.Enabled() {
  			serverConfig.Rand = boring.RandReader
@@ -2271,12 +2271,12 @@ index 7d85b39c59..fe2719485b 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build !boringcrypto
 +//go:build no_openssl
-
+ 
  package tls
-
+ 
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
 index 095b58c315..ac06591ea8 100644
 --- a/src/crypto/x509/boring.go
@@ -2284,12 +2284,12 @@ index 095b58c315..ac06591ea8 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package x509
-
+ 
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
 index 102acda578..07b3c7095e 100644
 --- a/src/crypto/x509/boring_test.go
@@ -2297,12 +2297,12 @@ index 102acda578..07b3c7095e 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto
 +//go:build !no_openssl
-
+ 
  package x509
-
+ 
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
 index c83a7272c9..0c7dea2f1f 100644
 --- a/src/crypto/x509/notboring.go
@@ -2310,12 +2310,12 @@ index c83a7272c9..0c7dea2f1f 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build !boringcrypto
 +//go:build no_openssl
-
+ 
  package x509
-
+ 
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
 index 8734dd03c1..22a104f338 100644
 --- a/src/crypto/x509/x509_test.go
@@ -2331,7 +2331,7 @@ index 8734dd03c1..22a104f338 100644
  	"crypto/rsa"
 @@ -653,7 +653,7 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
-
+ 
  	for _, test := range tests {
 -		if boring.Enabled && test.sigAlgo.isRSAPSS() {
 +		if boring.Enabled() && test.sigAlgo.isRSAPSS() {
@@ -2353,7 +2353,7 @@ index 4697da201c..0a5e32e27a 100644
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.20
-
+ 
  require (
 +	github.com/golang-fips/openssl-fips v0.0.0-20230323210700-e1541889d8a8
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
@@ -3170,14 +3170,14 @@ index e15f3682c7..5e1e789da0 100644
 @@ -2,19 +2,24 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -3189,19 +3189,19 @@ index e15f3682c7..5e1e789da0 100644
  	"runtime"
 +	"unsafe"
  )
-
+ 
  type ecdsaSignature struct {
 -	R, S BigInt
 +	R, S *big.Int
  }
-
+ 
  type PrivateKeyECDSA struct {
 @@ -34,11 +39,15 @@ func (k *PublicKeyECDSA) finalize() {
  }
-
+ 
  var errUnknownCurve = errors.New("boringcrypto: unknown elliptic curve")
 +var errUnsupportedCurve = errors.New("boringcrypto: unsupported elliptic curve")
-
+ 
  func curveNID(curve string) (C.int, error) {
  	switch curve {
  	case "P-224":
@@ -3250,7 +3250,7 @@ index e15f3682c7..5e1e789da0 100644
 @@ -119,19 +128,55 @@ func NewPrivateKeyECDSA(curve string, X, Y BigInt, D BigInt) (*PrivateKeyECDSA,
  	return k, nil
  }
-
+ 
 +func HashSignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (*big.Int, *big.Int, error) {
 +	size := C._goboringcrypto_ECDSA_size(priv.key)
 +	sig := make([]byte, size)
@@ -3285,7 +3285,7 @@ index e15f3682c7..5e1e789da0 100644
  	runtime.KeepAlive(priv)
  	return sig[:sigLen], nil
  }
-
+ 
  func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 -	ok := C._goboringcrypto_ECDSA_verify(0, base(hash), C.size_t(len(hash)), base(sig), C.size_t(len(sig)), pub.key) != 0
 +	ok := C._goboringcrypto_internal_ECDSA_verify(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
@@ -4630,14 +4630,14 @@ index 6241a65f5f..6f001777ae 100644
 @@ -2,14 +2,14 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -4649,7 +4649,7 @@ index 6241a65f5f..6f001777ae 100644
 @@ -67,13 +67,25 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
  		return nil
  	}
-
+ 
 -	// Note: Could hash down long keys here using EVP_Digest.
 -	hkey := bytes.Clone(key)
 +	var hkey []byte
@@ -4675,7 +4675,7 @@ index 6241a65f5f..6f001777ae 100644
  	hmac.Reset()
  	return hmac
 @@ -81,8 +93,8 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
-
+ 
  type boringHMAC struct {
  	md          *C.GO_EVP_MD
 -	ctx         C.GO_HMAC_CTX
@@ -4687,7 +4687,7 @@ index 6241a65f5f..6f001777ae 100644
  	key         []byte
 @@ -91,9 +103,7 @@ type boringHMAC struct {
  }
-
+ 
  func (h *boringHMAC) Reset() {
 -	if h.needCleanup {
 -		C._goboringcrypto_HMAC_CTX_cleanup(&h.ctx)
@@ -4702,7 +4702,7 @@ index 6241a65f5f..6f001777ae 100644
  	}
 -	C._goboringcrypto_HMAC_CTX_init(&h.ctx)
 +	C._goboringcrypto_HMAC_CTX_reset(h.ctx)
-
+ 
 -	if C._goboringcrypto_HMAC_Init(&h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md) == 0 {
 +	if C._goboringcrypto_HMAC_Init_ex(h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md, nil) == 0 {
  		panic("boringcrypto: HMAC_Init failed")
@@ -4716,12 +4716,12 @@ index 6241a65f5f..6f001777ae 100644
  	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
 @@ -115,12 +125,12 @@ func (h *boringHMAC) Reset() {
  }
-
+ 
  func (h *boringHMAC) finalize() {
 -	C._goboringcrypto_HMAC_CTX_cleanup(&h.ctx)
 +	C._goboringcrypto_HMAC_CTX_free(h.ctx)
  }
-
+ 
  func (h *boringHMAC) Write(p []byte) (int, error) {
  	if len(p) > 0 {
 -		C._goboringcrypto_HMAC_Update(&h.ctx, (*C.uint8_t)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
@@ -4755,14 +4755,14 @@ index 1c5e4c742d..2fa4a38e44 100644
 @@ -2,32 +2,34 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build !(boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan && cgo)
 +//go:build !linux || !cgo || android || cmd_go_bootstrap || msan || no_openssl
 +// +build !linux !cgo android cmd_go_bootstrap msan no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
  import (
  	"crypto"
  	"crypto/cipher"
@@ -4770,10 +4770,10 @@ index 1c5e4c742d..2fa4a38e44 100644
  	"hash"
 +	"io"
  )
-
+ 
 -const available = false
 +var enabled = false
-
+ 
  // Unreachable marks code that should be unreachable
  // when BoringCrypto is in use. It is a no-op without BoringCrypto.
  func Unreachable() {
@@ -4782,23 +4782,23 @@ index 1c5e4c742d..2fa4a38e44 100644
 -	// standard Go crypto.
 -	sig.StandardCrypto()
  }
-
+ 
  // UnreachableExceptTests marks code that should be unreachable
  // when BoringCrypto is in use. It is a no-op without BoringCrypto.
  func UnreachableExceptTests() {}
-
+ 
 +func ExecutingTest() bool { return false }
 +
 +// This is a noop withotu BoringCrytpo.
 +func PanicIfStrictFIPS(v interface{}) {}
 +
  type randReader int
-
+ 
  func (randReader) Read(b []byte) (int, error) { panic("boringcrypto: not available") }
 @@ -40,16 +42,9 @@ func NewSHA256() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA384() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA512() hash.Hash { panic("boringcrypto: not available") }
-
+ 
 -func SHA1([]byte) [20]byte   { panic("boringcrypto: not available") }
 -func SHA224([]byte) [28]byte { panic("boringcrypto: not available") }
 -func SHA256([]byte) [32]byte { panic("boringcrypto: not available") }
@@ -4806,10 +4806,10 @@ index 1c5e4c742d..2fa4a38e44 100644
 -func SHA512([]byte) [64]byte { panic("boringcrypto: not available") }
 -
  func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("boringcrypto: not available") }
-
+ 
  func NewAESCipher(key []byte) (cipher.Block, error) { panic("boringcrypto: not available") }
 -func NewGCMTLS(cipher.Block) (cipher.AEAD, error)   { panic("boringcrypto: not available") }
-
+ 
  type PublicKeyECDSA struct{ _ int }
  type PrivateKeyECDSA struct{ _ int }
 @@ -63,17 +58,39 @@ func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error)
@@ -4846,10 +4846,10 @@ index 1c5e4c742d..2fa4a38e44 100644
 +func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
  	panic("boringcrypto: not available")
  }
-
+ 
  type PublicKeyRSA struct{ _ int }
  type PrivateKeyRSA struct{ _ int }
-
+ 
 -func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 +func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
  	panic("boringcrypto: not available")
@@ -4882,13 +4882,13 @@ index 1c5e4c742d..2fa4a38e44 100644
  func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
  	panic("boringcrypto: not available")
  }
-
+ 
 -type PublicKeyECDH struct{}
 -type PrivateKeyECDH struct{}
 +func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 +	panic("boringcrypto: not available")
 +}
-
+ 
 -func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)      { panic("boringcrypto: not available") }
 -func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
 -func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) { panic("boringcrypto: not available") }
@@ -6373,19 +6373,19 @@ index 7639c01909..b3668b8823 100644
 @@ -2,11 +2,12 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
  import "unsafe"
-
+ 
 @@ -16,7 +17,7 @@ func (randReader) Read(b []byte) (int, error) {
  	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
  	// We check it even so.
@@ -6405,14 +6405,14 @@ index fa693ea319..75ba7a8a59 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -6423,19 +6423,19 @@ index fa693ea319..75ba7a8a59 100644
  	"hash"
  	"runtime"
 @@ -25,12 +25,12 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
-
+ 
  	key := C._goboringcrypto_RSA_new()
  	if key == nil {
 -		return bad(fail("RSA_new"))
 +		return bad(NewOpenSSLError("RSA_new failed"))
  	}
  	defer C._goboringcrypto_RSA_free(key)
-
+ 
  	if C._goboringcrypto_RSA_generate_key_fips(key, C.int(bits), nil) == 0 {
 -		return bad(fail("RSA_generate_key_fips"))
 +		return bad(NewOpenSSLError("RSA_generate_key_fips failed"))
  	}
-
+ 
  	var n, e, d, p, q, dp, dq, qinv *C.GO_BIGNUM
 @@ -48,12 +48,12 @@ type PublicKeyRSA struct {
  func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
@@ -6492,7 +6492,7 @@ index fa693ea319..75ba7a8a59 100644
  	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
 @@ -109,7 +115,7 @@ func (k *PrivateKeyRSA) withKey(f func(*C.GO_RSA) C.int) C.int {
  }
-
+ 
  func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 -	padding C.int, h, mgfHash hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 +	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
@@ -6500,7 +6500,7 @@ index fa693ea319..75ba7a8a59 100644
  	defer func() {
  		if err != nil {
 @@ -126,7 +132,7 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
-
+ 
  	pkey = C._goboringcrypto_EVP_PKEY_new()
  	if pkey == nil {
 -		return nil, nil, fail("EVP_PKEY_new")
@@ -6582,24 +6582,24 @@ index fa693ea319..75ba7a8a59 100644
 +			return nil, nil, NewOpenSSLError("EVP_PKEY_set_rsa_mgf1_md failed")
  		}
  	}
-
+ 
 @@ -187,12 +197,12 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
  }
-
+ 
  func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 -	padding C.int, h, mgfHash hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 +	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
  	init func(*C.GO_EVP_PKEY_CTX) C.int,
  	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.size_t, *C.uint8_t, C.size_t) C.int,
  	in []byte) ([]byte, error) {
-
+ 
 -	pkey, ctx, err := setupRSA(withKey, padding, h, mgfHash, label, saltLen, ch, init)
 +	pkey, ctx, err := setupRSA(withKey, padding, h, label, saltLen, ch, init)
  	if err != nil {
  		return nil, err
  	}
 @@ -201,37 +211,37 @@ func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
-
+ 
  	var outLen C.size_t
  	if crypt(ctx, nil, &outLen, base(in), C.size_t(len(in))) == 0 {
 -		return nil, fail("EVP_PKEY_decrypt/encrypt")
@@ -6613,50 +6613,50 @@ index fa693ea319..75ba7a8a59 100644
  	}
  	return out[:outLen], nil
  }
-
+ 
 -func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, 0, 0, decryptInit, decrypt, ciphertext)
 +func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 +	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, decryptInit, decrypt, ciphertext)
  }
-
+ 
 -func EncryptRSAOAEP(h, mgfHash hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, 0, 0, encryptInit, encrypt, msg)
 +func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
 +	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, encryptInit, encrypt, msg)
  }
-
+ 
  func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
 +	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
  }
-
+ 
  func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, 0, 0, encryptInit, encrypt, msg)
 +	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, 0, 0, encryptInit, encrypt, msg)
  }
-
+ 
  func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
 +	return cryptRSA(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
  }
-
+ 
  func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, 0, 0, encryptInit, encrypt, msg)
 +	return cryptRSA(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, 0, 0, encryptInit, encrypt, msg)
  }
-
+ 
  // These dumb wrappers work around the fact that cgo functions cannot be used as values directly.
 @@ -252,6 +262,10 @@ func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uin
  	return C._goboringcrypto_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
  }
-
+ 
 +// These should match crypto/rsa/pss.go
 +const saltLengthAuto = 0
 +const saltLengthEqualsHash = -1
 +
  var invalidSaltLenErr = errors.New("crypto/rsa: PSSOptions.SaltLength cannot be negative")
-
+ 
  func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
 @@ -259,27 +273,24 @@ func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int)
  	if md == nil {
@@ -6740,7 +6740,7 @@ index fa693ea319..75ba7a8a59 100644
  	}
  	return nil
  }
-
+ 
 -func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
 -	if h == 0 {
 -		// No hashing.
@@ -6772,7 +6772,7 @@ index fa693ea319..75ba7a8a59 100644
 +		runtime.KeepAlive(priv)
  		return out[:outLen], nil
  	}
-
+ 
 -	md := cryptoHashToMD(h)
 -	if md == nil {
 -		return nil, errors.New("crypto/rsa: unsupported hash function: " + strconv.Itoa(int(h)))
@@ -6808,7 +6808,7 @@ index fa693ea319..75ba7a8a59 100644
 +	runtime.KeepAlive(priv)
  	return out[:outLen], nil
  }
-
+ 
 -func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
 -	if h == 0 {
 -		var out []byte
@@ -6893,18 +6893,18 @@ index cf82f3f64f..0b55cedc91 100644
 @@ -2,12 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
-
+ 
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
-
+ 
 -package boring
 +package openssl
-
+ 
  /*
 -#include "goboringcrypto.h"
 +#include "goopenssl.h"
-
+ 
  int
  _goboringcrypto_gosha1(void *p, size_t n, void *out)
 @@ -17,7 +18,6 @@ _goboringcrypto_gosha1(void *p, size_t n, void *out)
@@ -6950,7 +6950,7 @@ index cf82f3f64f..0b55cedc91 100644
 @@ -126,31 +122,24 @@ type sha1Ctx struct {
  	nx     uint32
  }
-
+ 
 -func (h *sha1Hash) noescapeCtx() *C.GO_SHA_CTX {
 -	return (*C.GO_SHA_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -6966,7 +6966,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha1Hash) Size() int            { return 20 }
 +func (h *sha1Hash) BlockSize() int       { return 64 }
 +func (h *sha1Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
+ 
  func (h *sha1Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA1_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA1_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -6974,7 +6974,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
-
+ 
 -func (h0 *sha1Hash) sum(dst []byte) []byte {
 +func (h0 *sha1Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -6985,12 +6985,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
-
+ 
  const (
 @@ -207,30 +196,24 @@ type sha224Hash struct {
  	out [224 / 8]byte
  }
-
+ 
 -func (h *sha224Hash) noescapeCtx() *C.GO_SHA256_CTX {
 -	return (*C.GO_SHA256_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7005,7 +7005,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha224Hash) Size() int            { return 224 / 8 }
 +func (h *sha224Hash) BlockSize() int       { return 64 }
 +func (h *sha224Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
+ 
  func (h *sha224Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA224_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA224_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7013,7 +7013,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
-
+ 
 -func (h0 *sha224Hash) sum(dst []byte) []byte {
 +func (h0 *sha224Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7024,12 +7024,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
-
+ 
  // NewSHA256 returns a new SHA256 hash.
 @@ -245,30 +228,24 @@ type sha256Hash struct {
  	out [256 / 8]byte
  }
-
+ 
 -func (h *sha256Hash) noescapeCtx() *C.GO_SHA256_CTX {
 -	return (*C.GO_SHA256_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7044,7 +7044,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha256Hash) Size() int            { return 256 / 8 }
 +func (h *sha256Hash) BlockSize() int       { return 64 }
 +func (h *sha256Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
+ 
  func (h *sha256Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA256_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA256_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7052,7 +7052,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
-
+ 
 -func (h0 *sha256Hash) sum(dst []byte) []byte {
 +func (h0 *sha256Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7063,12 +7063,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
-
+ 
  const (
 @@ -382,30 +359,24 @@ type sha384Hash struct {
  	out [384 / 8]byte
  }
-
+ 
 -func (h *sha384Hash) noescapeCtx() *C.GO_SHA512_CTX {
 -	return (*C.GO_SHA512_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7083,7 +7083,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha384Hash) Size() int            { return 384 / 8 }
 +func (h *sha384Hash) BlockSize() int       { return 128 }
 +func (h *sha384Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
+ 
  func (h *sha384Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA384_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA384_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7091,7 +7091,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
-
+ 
 -func (h0 *sha384Hash) sum(dst []byte) []byte {
 +func (h0 *sha384Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7102,12 +7102,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
-
+ 
  // NewSHA512 returns a new SHA512 hash.
 @@ -420,30 +391,24 @@ type sha512Hash struct {
  	out [512 / 8]byte
  }
-
+ 
 -func (h *sha512Hash) noescapeCtx() *C.GO_SHA512_CTX {
 -	return (*C.GO_SHA512_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7122,7 +7122,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha512Hash) Size() int            { return 512 / 8 }
 +func (h *sha512Hash) BlockSize() int       { return 128 }
 +func (h *sha512Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
-
+ 
  func (h *sha512Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA512_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA512_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7130,7 +7130,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
-
+ 
 -func (h0 *sha512Hash) sum(dst []byte) []byte {
 +func (h0 *sha512Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7141,7 +7141,7 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
-
+ 
  type sha512Ctx struct {
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
 index 89a7c86c41..d3e88755be 100644

--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -5,15 +5,15 @@ index a9ec6e6bfe..7111867b66 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package api
- 
+
 @@ -12,6 +12,6 @@ import (
  )
- 
+
  func init() {
 -	fmt.Printf("SKIP with boringcrypto enabled\n")
 +	fmt.Printf("SKIP with !no_openssl enabled\n")
@@ -31,7 +31,7 @@ index 183c1697c8..abe85b5ad3 100644
 +	boring "crypto/internal/backend"
  	"strconv"
  )
- 
+
 @@ -38,7 +38,7 @@ func NewCipher(key []byte) (cipher.Block, error) {
  	case 16, 24, 32:
  		break
@@ -61,10 +61,10 @@ index 097c37e343..47618fe3c6 100644
 @@ -13,9 +13,9 @@
  // is satisfied, so that applications can tag files that use this package.
  package boring
- 
+
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
- 
+
  // Enabled reports whether BoringCrypto handles supported crypto operations.
  func Enabled() bool {
 -	return boring.Enabled
@@ -123,7 +123,7 @@ index 74420559b5..acf71ba580 100644
 --- a/src/crypto/ecdh/ecdh.go
 +++ b/src/crypto/ecdh/ecdh.go
 @@ -8,7 +8,7 @@ package ecdh
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -190,7 +190,7 @@ index 01354fa2cf..a7f1d9eced 100644
 +++ b/src/crypto/ecdh/nist.go
 @@ -5,7 +5,7 @@
  package ecdh
- 
+
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -199,7 +199,7 @@ index 01354fa2cf..a7f1d9eced 100644
  	"encoding/binary"
 @@ -36,7 +36,7 @@ func (c *nistCurve[Point]) String() string {
  var errInvalidPrivateKey = errors.New("crypto/ecdh: invalid private key")
- 
+
  func (c *nistCurve[Point]) GenerateKey(rand io.Reader) (*PrivateKey, error) {
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
@@ -227,12 +227,12 @@ index 01354fa2cf..a7f1d9eced 100644
 @@ -196,7 +196,7 @@ func (c *nistCurve[Point]) ecdh(local *PrivateKey, remote *PublicKey) ([]byte, e
  	// only be the result of a scalar multiplication if one of the inputs is the
  	// zero scalar or the point at infinity.
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		return boring.ECDH(local.boring, remote.boring)
  	}
- 
+
 diff --git a/src/crypto/ecdsa/boring.go b/src/crypto/ecdsa/boring.go
 index 275c60b4de..58f0034b18 100644
 --- a/src/crypto/ecdsa/boring.go
@@ -240,12 +240,12 @@ index 275c60b4de..58f0034b18 100644
 @@ -2,13 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package ecdsa
- 
+
  import (
 -	"crypto/internal/boring"
 -	"crypto/internal/boring/bbig"
@@ -272,7 +272,7 @@ index 03a9a72ddd..4bf497f9cc 100644
 @@ -154,7 +154,7 @@ func (priv *PrivateKey) Sign(rand io.Reader, digest []byte, opts crypto.SignerOp
  func GenerateKey(c elliptic.Curve, rand io.Reader) (*PrivateKey, error) {
  	randutil.MaybeReadByte(rand)
- 
+
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
  		x, y, d, err := boring.GenerateKeyECDSA(c.Params().Name)
@@ -281,7 +281,7 @@ index 03a9a72ddd..4bf497f9cc 100644
 @@ -248,7 +248,7 @@ var errNoAsm = errors.New("no assembly implementation available")
  func SignASN1(rand io.Reader, priv *PrivateKey, hash []byte) ([]byte, error) {
  	randutil.MaybeReadByte(rand)
- 
+
 -	if boring.Enabled && rand == boring.RandReader {
 +	if boring.Enabled() && rand == boring.RandReader {
  		b, err := boringPrivateKey(priv)
@@ -301,7 +301,7 @@ index 37f3a18223..51e3b49cdc 100644
 --- a/src/crypto/ecdsa/ecdsa_hashsignverify.go
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify.go
 @@ -2,7 +2,7 @@ package ecdsa
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -312,7 +312,7 @@ index 37f3a18223..51e3b49cdc 100644
 @@ -11,7 +11,7 @@ import (
  func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) (*big.Int, *big.Int, error) {
  	randutil.MaybeReadByte(rand)
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		b, err := boringPrivateKey(priv)
@@ -320,7 +320,7 @@ index 37f3a18223..51e3b49cdc 100644
  			return nil, nil, err
 @@ -28,7 +28,7 @@ func HashSign(rand io.Reader, priv *PrivateKey, msg []byte, h crypto.Hash) (*big
  }
- 
+
  func HashVerify(pub *PublicKey, msg []byte, r, s *big.Int, h crypto.Hash) bool {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -332,7 +332,7 @@ index d12ba2f441..6334a56496 100644
 --- a/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 +++ b/src/crypto/ecdsa/ecdsa_hashsignverify_test.go
 @@ -2,7 +2,7 @@ package ecdsa
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -343,7 +343,7 @@ index d12ba2f441..6334a56496 100644
 @@ -34,7 +34,7 @@ func testHashSignAndHashVerify(t *testing.T, c elliptic.Curve, tag string) {
  func TestHashSignAndHashVerify(t *testing.T) {
  	testHashSignAndHashVerify(t, elliptic.P256(), "p256")
- 
+
 -	if testing.Short() && !boring.Enabled {
 +	if testing.Short() && !boring.Enabled() {
  		return
@@ -381,7 +381,7 @@ index 61a4662036..80e484842b 100644
  		}
  		curve := test.curve
 @@ -246,7 +246,7 @@ func TestVectors(t *testing.T) {
- 
+
  			switch curve {
  			case "P-224":
 -				if !boring.Enabled || boringtest.Supports(t, "CurveP224") {
@@ -418,15 +418,15 @@ index 039bd82ed2..21a35b760c 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build !boringcrypto
 +//go:build no_openssl
- 
+
  package ecdsa
- 
+
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
- 
+
  func boringPublicKey(*PublicKey) (*boring.PublicKeyECDSA, error) {
 -	panic("boringcrypto: not available")
 +	panic("!no_openssl: not available")
@@ -449,7 +449,7 @@ index 8b5c2cc9af..ebbb1c0c07 100644
  	"crypto/sha512"
  	"encoding/hex"
 @@ -322,7 +322,7 @@ func TestMalleability(t *testing.T) {
- 
+
  func TestAllocations(t *testing.T) {
  	t.Skip("Allocations test broken with openssl linkage")
 -	if boring.Enabled {
@@ -463,7 +463,7 @@ index ed3ebc0602..9941228156 100644
 +++ b/src/crypto/hmac/hmac.go
 @@ -22,7 +22,7 @@ timing side-channels:
  package hmac
- 
+
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -484,7 +484,7 @@ index 55415abf02..0edd7a6003 100644
 --- a/src/crypto/hmac/hmac_test.go
 +++ b/src/crypto/hmac/hmac_test.go
 @@ -6,7 +6,7 @@ package hmac
- 
+
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -494,7 +494,7 @@ index 55415abf02..0edd7a6003 100644
  	"crypto/sha256"
 @@ -584,8 +584,8 @@ func TestHMAC(t *testing.T) {
  }
- 
+
  func TestNonUniqueHash(t *testing.T) {
 -	if boring.Enabled {
 -		t.Skip("hash.Hash provided by boringcrypto are not comparable")
@@ -1367,10 +1367,10 @@ index f2e5a503ea..65918a480e 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  // runtime_arg0 is declared in tls.go without a body.
  // It's provided by package runtime,
 diff --git a/src/crypto/internal/boring/fipstls/tls.go b/src/crypto/internal/boring/fipstls/tls.go
@@ -1380,23 +1380,23 @@ index 3bf1471fb0..d6c5ca736d 100644
 @@ -2,10 +2,10 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  // Package fipstls allows control over whether crypto/tls requires FIPS-approved settings.
 -// This package only exists with GOEXPERIMENT=boringcrypto, but the effects are independent
 +// This package only exists with GOEXPERIMENT=!no_openssl, but the effects are independent
  // of the use of BoringCrypto.
  package fipstls
- 
+
 diff --git a/src/crypto/rand/rand_unix.go b/src/crypto/rand/rand_unix.go
 index 40fce36314..c30be35635 100644
 --- a/src/crypto/rand/rand_unix.go
 +++ b/src/crypto/rand/rand_unix.go
 @@ -10,7 +10,7 @@
  package rand
- 
+
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
@@ -1405,7 +1405,7 @@ index 40fce36314..c30be35635 100644
  	"os"
 @@ -23,7 +23,7 @@ import (
  const urandomDevice = "/dev/urandom"
- 
+
  func init() {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1419,12 +1419,12 @@ index b9f9d3154f..85c2a45848 100644
 @@ -2,13 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package rsa
- 
+
  import (
 -	"crypto/internal/boring"
 -	"crypto/internal/boring/bbig"
@@ -1440,10 +1440,10 @@ index 2234d079f0..4e7fd9de4a 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  // Note: Can run these tests against the non-BoringCrypto
  // version of the code by using "CGO_ENABLED=0 go test".
 diff --git a/src/crypto/rsa/notboring.go b/src/crypto/rsa/notboring.go
@@ -1453,15 +1453,15 @@ index 2abc043640..a83be6dfdb 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build !boringcrypto
 +//go:build no_openssl
- 
+
  package rsa
- 
+
 -import "crypto/internal/boring"
 +import boring "crypto/internal/backend"
- 
+
  func boringPublicKey(*PublicKey) (*boring.PublicKeyRSA, error) {
 -	panic("boringcrypto: not available")
 +	panic("!no_openssl: not available")
@@ -1475,7 +1475,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 --- a/src/crypto/rsa/pkcs1v15.go
 +++ b/src/crypto/rsa/pkcs1v15.go
 @@ -6,7 +6,7 @@ package rsa
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1486,7 +1486,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -46,7 +46,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  		return nil, ErrMessageTooLong
  	}
- 
+
 -	if boring.Enabled && random == boring.RandReader {
 +	if boring.Enabled() && random == boring.RandReader {
  		bkey, err := boringPublicKey(pub)
@@ -1495,7 +1495,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -66,7 +66,7 @@ func EncryptPKCS1v15(random io.Reader, pub *PublicKey, msg []byte) ([]byte, erro
  	em[len(em)-len(msg)-1] = 0
  	copy(mm, msg)
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PublicKeyRSA
@@ -1504,7 +1504,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -91,7 +91,7 @@ func DecryptPKCS1v15(random io.Reader, priv *PrivateKey, ciphertext []byte) ([]b
  		return nil, err
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1513,7 +1513,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -170,7 +170,7 @@ func decryptPKCS1v15(priv *PrivateKey, ciphertext []byte) (valid int, em []byte,
  		return
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PrivateKeyRSA
@@ -1522,7 +1522,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 @@ -278,12 +278,12 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
  		return nil, ErrMessageTooLong
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1532,7 +1532,7 @@ index e51b9d2ca7..2d5f6b5ea9 100644
 -		return boring.SignRSAPKCS1v15(bkey, hash, hashed)
 +		return boring.SignRSAPKCS1v15(bkey, hash, hashed, true)
  	}
- 
+
  	// EM = 0x00 || 0x01 || PS || 0x00 || T
 @@ -304,12 +304,12 @@ func SignPKCS1v15(random io.Reader, priv *PrivateKey, hash crypto.Hash, hashed [
  // returning a nil error. If hash is zero then hashed is used directly. This
@@ -1564,49 +1564,49 @@ index 39a4fc184a..0853178e3a 100644
  	. "crypto/rsa"
 @@ -56,7 +56,7 @@ var decryptPKCS1v15Tests = []DecryptPKCS1v15Test{
  }
- 
+
  func TestDecryptPKCS1v15(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
- 
+
 @@ -84,7 +84,7 @@ func TestDecryptPKCS1v15(t *testing.T) {
  }
- 
+
  func TestEncryptPKCS1v15(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
- 
+
 @@ -149,7 +149,7 @@ var decryptPKCS1v15SessionKeyTests = []DecryptPKCS1v15Test{
  }
- 
+
  func TestEncryptPKCS1v15SessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
- 
+
 @@ -167,7 +167,7 @@ func TestEncryptPKCS1v15SessionKey(t *testing.T) {
  }
- 
+
  func TestEncryptPKCS1v15DecrypterSessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
- 
+
 @@ -277,7 +277,7 @@ func TestUnpaddedSignature(t *testing.T) {
  }
- 
+
  func TestShortSessionKey(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "PKCSv1.5") {
 +	if boring.Enabled() && !boringtest.Supports(t, "PKCSv1.5") {
  		t.Skip("skipping PKCS#1 v1.5 encryption test with BoringCrypto")
  	}
- 
+
 diff --git a/src/crypto/rsa/pss.go b/src/crypto/rsa/pss.go
 index f7d23b55ef..3c822aa587 100644
 --- a/src/crypto/rsa/pss.go
@@ -1623,7 +1623,7 @@ index f7d23b55ef..3c822aa587 100644
 @@ -214,7 +214,7 @@ func signPSSWithSalt(priv *PrivateKey, hash crypto.Hash, hashed, salt []byte) ([
  		return nil, err
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1668,16 +1668,16 @@ index 1226149321..befd1612b5 100644
 +	if boring.Enabled() {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
- 
+
 @@ -209,7 +209,7 @@ func TestPSSNilOpts(t *testing.T) {
  }
- 
+
  func TestPSSSigning(t *testing.T) {
 -	if boring.Enabled && !boringtest.Supports(t, "SHA1") {
 +	if boring.Enabled() && !boringtest.Supports(t, "SHA1") {
  		t.Skip("skipping PSS test with BoringCrypto: too short key")
  	}
- 
+
 diff --git a/src/crypto/rsa/rsa.go b/src/crypto/rsa/rsa.go
 index ab56ccd1ed..dd79dc5439 100644
 --- a/src/crypto/rsa/rsa.go
@@ -1696,7 +1696,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -286,7 +286,7 @@ func GenerateKey(random io.Reader, bits int) (*PrivateKey, error) {
  func GenerateMultiPrimeKey(random io.Reader, nprimes int, bits int) (*PrivateKey, error) {
  	randutil.MaybeReadByte(random)
- 
+
 -	if boring.Enabled && random == boring.RandReader && nprimes == 2 &&
 +	if boring.Enabled() && random == boring.RandReader && nprimes == 2 &&
  		(bits == 2048 || bits == 3072 || bits == 4096) {
@@ -1705,7 +1705,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -504,7 +504,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
  		return nil, ErrMessageTooLong
  	}
- 
+
 -	if boring.Enabled && random == boring.RandReader {
 +	if boring.Enabled() && random == boring.RandReader {
  		bkey, err := boringPublicKey(pub)
@@ -1714,7 +1714,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -533,7 +533,7 @@ func EncryptOAEP(hash hash.Hash, random io.Reader, pub *PublicKey, msg []byte, l
  	mgf1XOR(db, hash, seed)
  	mgf1XOR(seed, hash, db)
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		var bkey *boring.PublicKeyRSA
@@ -1723,7 +1723,7 @@ index ab56ccd1ed..dd79dc5439 100644
 @@ -675,7 +675,7 @@ func decryptOAEP(hash, mgfHash hash.Hash, random io.Reader, priv *PrivateKey, ci
  		return nil, ErrDecryption
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		bkey, err := boringPrivateKey(priv)
@@ -1754,7 +1754,7 @@ index b994daec19..4b7427e1ae 100644
 @@ -120,12 +120,12 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  		t.Errorf("private exponent too large")
  	}
- 
+
 -	if boring.Enabled {
 +	if boring.Enabled() {
  		// Cannot call encrypt/decrypt with raw RSA. PKCSv1.5
@@ -1768,7 +1768,7 @@ index b994daec19..4b7427e1ae 100644
  		}
 @@ -167,7 +167,7 @@ func testKeyBasics(t *testing.T, priv *PrivateKey) {
  }
- 
+
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1805,12 +1805,12 @@ index b994daec19..4b7427e1ae 100644
 @@ -741,7 +741,7 @@ func Test2DecryptOAEP(t *testing.T) {
  	sha1 := crypto.SHA1
  	sha256 := crypto.SHA256
- 
+
 -	if boring.Enabled && n.BitLen() < 2048 {
 +	if boring.Enabled() && n.BitLen() < 2048 {
  		t.Skipf("skipping encryption tests with BoringCrypto: too short key: %d", n.BitLen())
  	}
- 
+
 @@ -760,7 +760,7 @@ func TestEncryptDecryptOAEP(t *testing.T) {
  	d := new(big.Int)
  	for i, test := range testEncryptOAEPData {
@@ -1826,18 +1826,18 @@ index b5786d1bf4..9bd03f3940 100644
 +++ b/src/crypto/sha1/boring.go
 @@ -12,11 +12,11 @@
  package sha1
- 
+
  import (
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
  	"hash"
  )
- 
+
 -const boringEnabled = boring.Enabled
 +var boringEnabled = boring.Enabled()
- 
+
  func boringNewSHA1() hash.Hash { return boring.NewSHA1() }
- 
+
 diff --git a/src/crypto/sha1/notboring.go b/src/crypto/sha1/notboring.go
 index 42ef87937f..c1a3205539 100644
 --- a/src/crypto/sha1/notboring.go
@@ -1845,15 +1845,15 @@ index 42ef87937f..c1a3205539 100644
 @@ -11,10 +11,10 @@ import (
  	"hash"
  )
- 
+
 -const boringEnabled = false
 +var boringEnabled = false
- 
+
 -func boringNewSHA1() hash.Hash { panic("boringcrypto: not available") }
 +func boringNewSHA1() hash.Hash { panic("!no_openssl: not available") }
- 
+
  func boringUnreachable() {}
- 
+
 -func boringSHA1([]byte) [20]byte { panic("boringcrypto: not available") }
 +func boringSHA1([]byte) [20]byte { panic("!no_openssl: not available") }
 diff --git a/src/crypto/sha1/sha1_test.go b/src/crypto/sha1/sha1_test.go
@@ -1861,7 +1861,7 @@ index 85ed126091..71f4b46663 100644
 --- a/src/crypto/sha1/sha1_test.go
 +++ b/src/crypto/sha1/sha1_test.go
 @@ -8,7 +8,7 @@ package sha1
- 
+
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -1879,7 +1879,7 @@ index 85ed126091..71f4b46663 100644
  				}
  				io.WriteString(c, g.in[0:len(g.in)/2])
 @@ -145,7 +145,7 @@ func TestBlockSize(t *testing.T) {
- 
+
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -1889,7 +1889,7 @@ index 85ed126091..71f4b46663 100644
  	for i := 1; i < 30; i++ { // arbitrary factor
 @@ -218,7 +218,7 @@ func TestLargeHashes(t *testing.T) {
  }
- 
+
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1901,7 +1901,7 @@ index 2deafbc9fc..282c326b32 100644
 --- a/src/crypto/sha256/sha256.go
 +++ b/src/crypto/sha256/sha256.go
 @@ -8,7 +8,7 @@ package sha256
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1919,7 +1919,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	d := new(digest)
 @@ -158,7 +158,7 @@ func New() hash.Hash {
- 
+
  // New224 returns a new hash.Hash computing the SHA224 checksum.
  func New224() hash.Hash {
 -	if boring.Enabled {
@@ -1928,7 +1928,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	d := new(digest)
 @@ -251,7 +251,7 @@ func (d *digest) checkSum() [Size]byte {
- 
+
  // Sum256 returns the SHA256 checksum of the data.
  func Sum256(data []byte) [Size]byte {
 -	if boring.Enabled {
@@ -1937,7 +1937,7 @@ index 2deafbc9fc..282c326b32 100644
  	}
  	var d digest
 @@ -262,7 +262,7 @@ func Sum256(data []byte) [Size]byte {
- 
+
  // Sum224 returns the SHA224 checksum of the data.
  func Sum224(data []byte) [Size224]byte {
 -	if boring.Enabled {
@@ -1950,7 +1950,7 @@ index 7304678346..a073d31119 100644
 --- a/src/crypto/sha256/sha256_test.go
 +++ b/src/crypto/sha256/sha256_test.go
 @@ -8,7 +8,7 @@ package sha256
- 
+
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -1959,7 +1959,7 @@ index 7304678346..a073d31119 100644
  	"encoding"
  	"fmt"
 @@ -217,7 +217,7 @@ func TestBlockSize(t *testing.T) {
- 
+
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -1969,7 +1969,7 @@ index 7304678346..a073d31119 100644
  	gen, asm := New().(*digest), New().(*digest)
 @@ -294,7 +294,7 @@ func TestLargeHashes(t *testing.T) {
  }
- 
+
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -1981,7 +1981,7 @@ index 9ae1b3aae2..e56eedb201 100644
 --- a/src/crypto/sha512/sha512.go
 +++ b/src/crypto/sha512/sha512.go
 @@ -12,7 +12,7 @@ package sha512
- 
+
  import (
  	"crypto"
 -	"crypto/internal/boring"
@@ -1990,7 +1990,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	"errors"
  	"hash"
 @@ -206,7 +206,7 @@ func consumeUint64(b []byte) ([]byte, uint64) {
- 
+
  // New returns a new hash.Hash computing the SHA-512 checksum.
  func New() hash.Hash {
 -	if boring.Enabled {
@@ -1999,7 +1999,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := &digest{function: crypto.SHA512}
 @@ -230,7 +230,7 @@ func New512_256() hash.Hash {
- 
+
  // New384 returns a new hash.Hash computing the SHA-384 checksum.
  func New384() hash.Hash {
 -	if boring.Enabled {
@@ -2008,7 +2008,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := &digest{function: crypto.SHA384}
 @@ -341,7 +341,7 @@ func (d *digest) checkSum() [Size]byte {
- 
+
  // Sum512 returns the SHA512 checksum of the data.
  func Sum512(data []byte) [Size]byte {
 -	if boring.Enabled {
@@ -2017,7 +2017,7 @@ index 9ae1b3aae2..e56eedb201 100644
  	}
  	d := digest{function: crypto.SHA512}
 @@ -352,7 +352,7 @@ func Sum512(data []byte) [Size]byte {
- 
+
  // Sum384 returns the SHA384 checksum of the data.
  func Sum384(data []byte) [Size384]byte {
 -	if boring.Enabled {
@@ -2030,7 +2030,7 @@ index 921cdbb7bb..a35165bcbf 100644
 --- a/src/crypto/sha512/sha512_test.go
 +++ b/src/crypto/sha512/sha512_test.go
 @@ -8,7 +8,7 @@ package sha512
- 
+
  import (
  	"bytes"
 -	"crypto/internal/boring"
@@ -2039,7 +2039,7 @@ index 921cdbb7bb..a35165bcbf 100644
  	"encoding"
  	"encoding/hex"
 @@ -823,7 +823,7 @@ func TestBlockSize(t *testing.T) {
- 
+
  // Tests that blockGeneric (pure Go) and block (in assembly for some architectures) match.
  func TestBlockGeneric(t *testing.T) {
 -	if boring.Enabled {
@@ -2049,7 +2049,7 @@ index 921cdbb7bb..a35165bcbf 100644
  	gen, asm := New().(*digest), New().(*digest)
 @@ -893,7 +893,7 @@ func TestLargeHashes(t *testing.T) {
  }
- 
+
  func TestAllocations(t *testing.T) {
 -	if boring.Enabled {
 +	if boring.Enabled() {
@@ -2063,15 +2063,15 @@ index 140b1a3dd8..fe6fa96d28 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package tls
- 
+
 @@ -12,7 +12,7 @@ import (
  )
- 
+
  func init() {
 -       if boring.Enabled && !boring.ExecutingTest() {
 +       if boring.Enabled() && !boring.ExecutingTest() {
@@ -2085,12 +2085,12 @@ index 7bfe3f9417..49702f59ba 100644
 @@ -2,14 +2,14 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package tls
- 
+
  import (
  	"crypto/ecdsa"
  	"crypto/elliptic"
@@ -2109,9 +2109,9 @@ index 7bfe3f9417..49702f59ba 100644
  	} else {
  		test("VersionTLS13", VersionTLS13, "")
 @@ -238,7 +238,7 @@ func TestBoringServerSignatureAndHash(t *testing.T) {
- 
+
  			clientConfig := testConfig.Clone()
- 
+
 -			if boring.Enabled {
 +			if boring.Enabled() {
  				serverConfig.Rand = boring.RandReader
@@ -2120,7 +2120,7 @@ index 7bfe3f9417..49702f59ba 100644
 @@ -369,7 +369,7 @@ func TestBoringCertAlgs(t *testing.T) {
  		serverConfig.Certificates = []Certificate{{Certificate: list, PrivateKey: key}}
  		serverConfig.BuildNameToCertificate()
- 
+
 -		if boring.Enabled {
 +		if boring.Enabled() {
  			serverConfig.Rand = boring.RandReader
@@ -2136,7 +2136,7 @@ index 7bfe3f9417..49702f59ba 100644
  			serverConfig.Certificates[0].PrivateKey = testRSA2048PrivateKey
  			serverConfig.BuildNameToCertificate()
  		}
- 
+
 -		if boring.Enabled {
 +		if boring.Enabled() {
  			serverConfig.Rand = boring.RandReader
@@ -2271,12 +2271,12 @@ index 7d85b39c59..fe2719485b 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build !boringcrypto
 +//go:build no_openssl
- 
+
  package tls
- 
+
 diff --git a/src/crypto/x509/boring.go b/src/crypto/x509/boring.go
 index 095b58c315..ac06591ea8 100644
 --- a/src/crypto/x509/boring.go
@@ -2284,12 +2284,12 @@ index 095b58c315..ac06591ea8 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package x509
- 
+
 diff --git a/src/crypto/x509/boring_test.go b/src/crypto/x509/boring_test.go
 index 102acda578..07b3c7095e 100644
 --- a/src/crypto/x509/boring_test.go
@@ -2297,12 +2297,12 @@ index 102acda578..07b3c7095e 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto
 +//go:build !no_openssl
- 
+
  package x509
- 
+
 diff --git a/src/crypto/x509/notboring.go b/src/crypto/x509/notboring.go
 index c83a7272c9..0c7dea2f1f 100644
 --- a/src/crypto/x509/notboring.go
@@ -2310,12 +2310,12 @@ index c83a7272c9..0c7dea2f1f 100644
 @@ -2,7 +2,7 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build !boringcrypto
 +//go:build no_openssl
- 
+
  package x509
- 
+
 diff --git a/src/crypto/x509/x509_test.go b/src/crypto/x509/x509_test.go
 index 8734dd03c1..22a104f338 100644
 --- a/src/crypto/x509/x509_test.go
@@ -2331,7 +2331,7 @@ index 8734dd03c1..22a104f338 100644
  	"crypto/rsa"
 @@ -653,7 +653,7 @@ func TestCreateSelfSignedCertificate(t *testing.T) {
  	extraExtensionData := []byte("extra extension")
- 
+
  	for _, test := range tests {
 -		if boring.Enabled && test.sigAlgo.isRSAPSS() {
 +		if boring.Enabled() && test.sigAlgo.isRSAPSS() {
@@ -2353,7 +2353,7 @@ index 4697da201c..a3891edd78 100644
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.20
- 
+
  require (
 +	github.com/golang-fips/openssl-fips v0.0.0-20230714114059-9051f24728fe
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
@@ -3170,14 +3170,14 @@ index e15f3682c7..5e1e789da0 100644
 @@ -2,19 +2,24 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
- 
+
 -package boring
 +package openssl
- 
+
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -3189,19 +3189,19 @@ index e15f3682c7..5e1e789da0 100644
  	"runtime"
 +	"unsafe"
  )
- 
+
  type ecdsaSignature struct {
 -	R, S BigInt
 +	R, S *big.Int
  }
- 
+
  type PrivateKeyECDSA struct {
 @@ -34,11 +39,15 @@ func (k *PublicKeyECDSA) finalize() {
  }
- 
+
  var errUnknownCurve = errors.New("boringcrypto: unknown elliptic curve")
 +var errUnsupportedCurve = errors.New("boringcrypto: unsupported elliptic curve")
- 
+
  func curveNID(curve string) (C.int, error) {
  	switch curve {
  	case "P-224":
@@ -3250,7 +3250,7 @@ index e15f3682c7..5e1e789da0 100644
 @@ -119,19 +128,55 @@ func NewPrivateKeyECDSA(curve string, X, Y BigInt, D BigInt) (*PrivateKeyECDSA,
  	return k, nil
  }
- 
+
 +func HashSignECDSA(priv *PrivateKeyECDSA, hash []byte, h crypto.Hash) (*big.Int, *big.Int, error) {
 +	size := C._goboringcrypto_ECDSA_size(priv.key)
 +	sig := make([]byte, size)
@@ -3285,7 +3285,7 @@ index e15f3682c7..5e1e789da0 100644
  	runtime.KeepAlive(priv)
  	return sig[:sigLen], nil
  }
- 
+
  func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 -	ok := C._goboringcrypto_ECDSA_verify(0, base(hash), C.size_t(len(hash)), base(sig), C.size_t(len(sig)), pub.key) != 0
 +	ok := C._goboringcrypto_internal_ECDSA_verify(0, base(hash), C.size_t(len(hash)), (*C.uint8_t)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), pub.key) > 0
@@ -4630,14 +4630,14 @@ index 6241a65f5f..6f001777ae 100644
 @@ -2,14 +2,14 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
- 
+
 -package boring
 +package openssl
- 
+
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -4649,7 +4649,7 @@ index 6241a65f5f..6f001777ae 100644
 @@ -67,13 +67,25 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
  		return nil
  	}
- 
+
 -	// Note: Could hash down long keys here using EVP_Digest.
 -	hkey := bytes.Clone(key)
 +	var hkey []byte
@@ -4675,7 +4675,7 @@ index 6241a65f5f..6f001777ae 100644
  	hmac.Reset()
  	return hmac
 @@ -81,8 +93,8 @@ func NewHMAC(h func() hash.Hash, key []byte) hash.Hash {
- 
+
  type boringHMAC struct {
  	md          *C.GO_EVP_MD
 -	ctx         C.GO_HMAC_CTX
@@ -4687,7 +4687,7 @@ index 6241a65f5f..6f001777ae 100644
  	key         []byte
 @@ -91,9 +103,7 @@ type boringHMAC struct {
  }
- 
+
  func (h *boringHMAC) Reset() {
 -	if h.needCleanup {
 -		C._goboringcrypto_HMAC_CTX_cleanup(&h.ctx)
@@ -4702,7 +4702,7 @@ index 6241a65f5f..6f001777ae 100644
  	}
 -	C._goboringcrypto_HMAC_CTX_init(&h.ctx)
 +	C._goboringcrypto_HMAC_CTX_reset(h.ctx)
- 
+
 -	if C._goboringcrypto_HMAC_Init(&h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md) == 0 {
 +	if C._goboringcrypto_HMAC_Init_ex(h.ctx, unsafe.Pointer(base(h.key)), C.int(len(h.key)), h.md, nil) == 0 {
  		panic("boringcrypto: HMAC_Init failed")
@@ -4716,12 +4716,12 @@ index 6241a65f5f..6f001777ae 100644
  	runtime.KeepAlive(h) // Next line will keep h alive too; just making doubly sure.
 @@ -115,12 +125,12 @@ func (h *boringHMAC) Reset() {
  }
- 
+
  func (h *boringHMAC) finalize() {
 -	C._goboringcrypto_HMAC_CTX_cleanup(&h.ctx)
 +	C._goboringcrypto_HMAC_CTX_free(h.ctx)
  }
- 
+
  func (h *boringHMAC) Write(p []byte) (int, error) {
  	if len(p) > 0 {
 -		C._goboringcrypto_HMAC_Update(&h.ctx, (*C.uint8_t)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
@@ -4755,14 +4755,14 @@ index 1c5e4c742d..2fa4a38e44 100644
 @@ -2,32 +2,34 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build !(boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan && cgo)
 +//go:build !linux || !cgo || android || cmd_go_bootstrap || msan || no_openssl
 +// +build !linux !cgo android cmd_go_bootstrap msan no_openssl
- 
+
 -package boring
 +package openssl
- 
+
  import (
  	"crypto"
  	"crypto/cipher"
@@ -4770,10 +4770,10 @@ index 1c5e4c742d..2fa4a38e44 100644
  	"hash"
 +	"io"
  )
- 
+
 -const available = false
 +var enabled = false
- 
+
  // Unreachable marks code that should be unreachable
  // when BoringCrypto is in use. It is a no-op without BoringCrypto.
  func Unreachable() {
@@ -4782,23 +4782,23 @@ index 1c5e4c742d..2fa4a38e44 100644
 -	// standard Go crypto.
 -	sig.StandardCrypto()
  }
- 
+
  // UnreachableExceptTests marks code that should be unreachable
  // when BoringCrypto is in use. It is a no-op without BoringCrypto.
  func UnreachableExceptTests() {}
- 
+
 +func ExecutingTest() bool { return false }
 +
 +// This is a noop withotu BoringCrytpo.
 +func PanicIfStrictFIPS(v interface{}) {}
 +
  type randReader int
- 
+
  func (randReader) Read(b []byte) (int, error) { panic("boringcrypto: not available") }
 @@ -40,16 +42,9 @@ func NewSHA256() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA384() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA512() hash.Hash { panic("boringcrypto: not available") }
- 
+
 -func SHA1([]byte) [20]byte   { panic("boringcrypto: not available") }
 -func SHA224([]byte) [28]byte { panic("boringcrypto: not available") }
 -func SHA256([]byte) [32]byte { panic("boringcrypto: not available") }
@@ -4806,10 +4806,10 @@ index 1c5e4c742d..2fa4a38e44 100644
 -func SHA512([]byte) [64]byte { panic("boringcrypto: not available") }
 -
  func NewHMAC(h func() hash.Hash, key []byte) hash.Hash { panic("boringcrypto: not available") }
- 
+
  func NewAESCipher(key []byte) (cipher.Block, error) { panic("boringcrypto: not available") }
 -func NewGCMTLS(cipher.Block) (cipher.AEAD, error)   { panic("boringcrypto: not available") }
- 
+
  type PublicKeyECDSA struct{ _ int }
  type PrivateKeyECDSA struct{ _ int }
 @@ -63,17 +58,39 @@ func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error)
@@ -4846,10 +4846,10 @@ index 1c5e4c742d..2fa4a38e44 100644
 +func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
  	panic("boringcrypto: not available")
  }
- 
+
  type PublicKeyRSA struct{ _ int }
  type PrivateKeyRSA struct{ _ int }
- 
+
 -func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 +func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
  	panic("boringcrypto: not available")
@@ -4882,13 +4882,13 @@ index 1c5e4c742d..2fa4a38e44 100644
  func VerifyRSAPSS(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte, saltLen int) error {
  	panic("boringcrypto: not available")
  }
- 
+
 -type PublicKeyECDH struct{}
 -type PrivateKeyECDH struct{}
 +func ExtractHKDF(h func() hash.Hash, secret, salt []byte) ([]byte, error) {
 +	panic("boringcrypto: not available")
 +}
- 
+
 -func ECDH(*PrivateKeyECDH, *PublicKeyECDH) ([]byte, error)      { panic("boringcrypto: not available") }
 -func GenerateKeyECDH(string) (*PrivateKeyECDH, []byte, error)   { panic("boringcrypto: not available") }
 -func NewPrivateKeyECDH(string, []byte) (*PrivateKeyECDH, error) { panic("boringcrypto: not available") }
@@ -6381,19 +6381,19 @@ index 7639c01909..b3668b8823 100644
 @@ -2,11 +2,12 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
- 
+
 -package boring
 +package openssl
- 
+
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
  import "unsafe"
- 
+
 @@ -16,7 +17,7 @@ func (randReader) Read(b []byte) (int, error) {
  	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
  	// We check it even so.
@@ -6413,14 +6413,14 @@ index fa693ea319..75ba7a8a59 100644
 @@ -2,15 +2,15 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
- 
+
 -package boring
 +package openssl
- 
+
 -// #include "goboringcrypto.h"
 +// #include "goopenssl.h"
  import "C"
@@ -6431,19 +6431,19 @@ index fa693ea319..75ba7a8a59 100644
  	"hash"
  	"runtime"
 @@ -25,12 +25,12 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
- 
+
  	key := C._goboringcrypto_RSA_new()
  	if key == nil {
 -		return bad(fail("RSA_new"))
 +		return bad(NewOpenSSLError("RSA_new failed"))
  	}
  	defer C._goboringcrypto_RSA_free(key)
- 
+
  	if C._goboringcrypto_RSA_generate_key_fips(key, C.int(bits), nil) == 0 {
 -		return bad(fail("RSA_generate_key_fips"))
 +		return bad(NewOpenSSLError("RSA_generate_key_fips failed"))
  	}
- 
+
  	var n, e, d, p, q, dp, dq, qinv *C.GO_BIGNUM
 @@ -48,12 +48,12 @@ type PublicKeyRSA struct {
  func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) {
@@ -6500,7 +6500,7 @@ index fa693ea319..75ba7a8a59 100644
  	runtime.SetFinalizer(k, (*PrivateKeyRSA).finalize)
 @@ -109,7 +115,7 @@ func (k *PrivateKeyRSA) withKey(f func(*C.GO_RSA) C.int) C.int {
  }
- 
+
  func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 -	padding C.int, h, mgfHash hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 +	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
@@ -6508,7 +6508,7 @@ index fa693ea319..75ba7a8a59 100644
  	defer func() {
  		if err != nil {
 @@ -126,7 +132,7 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
- 
+
  	pkey = C._goboringcrypto_EVP_PKEY_new()
  	if pkey == nil {
 -		return nil, nil, fail("EVP_PKEY_new")
@@ -6590,24 +6590,24 @@ index fa693ea319..75ba7a8a59 100644
 +			return nil, nil, NewOpenSSLError("EVP_PKEY_set_rsa_mgf1_md failed")
  		}
  	}
- 
+
 @@ -187,12 +197,12 @@ func setupRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
  }
- 
+
  func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
 -	padding C.int, h, mgfHash hash.Hash, label []byte, saltLen int, ch crypto.Hash,
 +	padding C.int, h hash.Hash, label []byte, saltLen int, ch crypto.Hash,
  	init func(*C.GO_EVP_PKEY_CTX) C.int,
  	crypt func(*C.GO_EVP_PKEY_CTX, *C.uint8_t, *C.size_t, *C.uint8_t, C.size_t) C.int,
  	in []byte) ([]byte, error) {
- 
+
 -	pkey, ctx, err := setupRSA(withKey, padding, h, mgfHash, label, saltLen, ch, init)
 +	pkey, ctx, err := setupRSA(withKey, padding, h, label, saltLen, ch, init)
  	if err != nil {
  		return nil, err
  	}
 @@ -201,37 +211,37 @@ func cryptRSA(withKey func(func(*C.GO_RSA) C.int) C.int,
- 
+
  	var outLen C.size_t
  	if crypt(ctx, nil, &outLen, base(in), C.size_t(len(in))) == 0 {
 -		return nil, fail("EVP_PKEY_decrypt/encrypt")
@@ -6621,50 +6621,50 @@ index fa693ea319..75ba7a8a59 100644
  	}
  	return out[:outLen], nil
  }
- 
+
 -func DecryptRSAOAEP(h, mgfHash hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, 0, 0, decryptInit, decrypt, ciphertext)
 +func DecryptRSAOAEP(h hash.Hash, priv *PrivateKeyRSA, ciphertext, label []byte) ([]byte, error) {
 +	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, decryptInit, decrypt, ciphertext)
  }
- 
+
 -func EncryptRSAOAEP(h, mgfHash hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, mgfHash, label, 0, 0, encryptInit, encrypt, msg)
 +func EncryptRSAOAEP(h hash.Hash, pub *PublicKeyRSA, msg, label []byte) ([]byte, error) {
 +	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_OAEP_PADDING, h, label, 0, 0, encryptInit, encrypt, msg)
  }
- 
+
  func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
 +	return cryptRSA(priv.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
  }
- 
+
  func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, nil, 0, 0, encryptInit, encrypt, msg)
 +	return cryptRSA(pub.withKey, C.GO_RSA_PKCS1_PADDING, nil, nil, 0, 0, encryptInit, encrypt, msg)
  }
- 
+
  func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
 -	return cryptRSA(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
 +	return cryptRSA(priv.withKey, C.GO_RSA_NO_PADDING, nil, nil, 0, 0, decryptInit, decrypt, ciphertext)
  }
- 
+
  func EncryptRSANoPadding(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
 -	return cryptRSA(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, nil, 0, 0, encryptInit, encrypt, msg)
 +	return cryptRSA(pub.withKey, C.GO_RSA_NO_PADDING, nil, nil, 0, 0, encryptInit, encrypt, msg)
  }
- 
+
  // These dumb wrappers work around the fact that cgo functions cannot be used as values directly.
 @@ -252,6 +262,10 @@ func encrypt(ctx *C.GO_EVP_PKEY_CTX, out *C.uint8_t, outLen *C.size_t, in *C.uin
  	return C._goboringcrypto_EVP_PKEY_encrypt(ctx, out, outLen, in, inLen)
  }
- 
+
 +// These should match crypto/rsa/pss.go
 +const saltLengthAuto = 0
 +const saltLengthEqualsHash = -1
 +
  var invalidSaltLenErr = errors.New("crypto/rsa: PSSOptions.SaltLength cannot be negative")
- 
+
  func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int) ([]byte, error) {
 @@ -259,27 +273,24 @@ func SignRSAPSS(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte, saltLen int)
  	if md == nil {
@@ -6748,7 +6748,7 @@ index fa693ea319..75ba7a8a59 100644
  	}
  	return nil
  }
- 
+
 -func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte, error) {
 -	if h == 0 {
 -		// No hashing.
@@ -6780,7 +6780,7 @@ index fa693ea319..75ba7a8a59 100644
 +		runtime.KeepAlive(priv)
  		return out[:outLen], nil
  	}
- 
+
 -	md := cryptoHashToMD(h)
 -	if md == nil {
 -		return nil, errors.New("crypto/rsa: unsupported hash function: " + strconv.Itoa(int(h)))
@@ -6816,7 +6816,7 @@ index fa693ea319..75ba7a8a59 100644
 +	runtime.KeepAlive(priv)
  	return out[:outLen], nil
  }
- 
+
 -func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) error {
 -	if h == 0 {
 -		var out []byte
@@ -6901,18 +6901,18 @@ index cf82f3f64f..0b55cedc91 100644
 @@ -2,12 +2,13 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
- 
+
 -//go:build boringcrypto && linux && (amd64 || arm64) && !android && !cmd_go_bootstrap && !msan
 +//go:build linux && !android && !cmd_go_bootstrap && !msan && !no_openssl
 +// +build linux,!android,!cmd_go_bootstrap,!msan,!no_openssl
- 
+
 -package boring
 +package openssl
- 
+
  /*
 -#include "goboringcrypto.h"
 +#include "goopenssl.h"
- 
+
  int
  _goboringcrypto_gosha1(void *p, size_t n, void *out)
 @@ -17,7 +18,6 @@ _goboringcrypto_gosha1(void *p, size_t n, void *out)
@@ -6958,7 +6958,7 @@ index cf82f3f64f..0b55cedc91 100644
 @@ -126,31 +122,24 @@ type sha1Ctx struct {
  	nx     uint32
  }
- 
+
 -func (h *sha1Hash) noescapeCtx() *C.GO_SHA_CTX {
 -	return (*C.GO_SHA_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -6974,7 +6974,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha1Hash) Size() int            { return 20 }
 +func (h *sha1Hash) BlockSize() int       { return 64 }
 +func (h *sha1Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
- 
+
  func (h *sha1Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA1_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA1_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -6982,7 +6982,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
- 
+
 -func (h0 *sha1Hash) sum(dst []byte) []byte {
 +func (h0 *sha1Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -6993,12 +6993,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
- 
+
  const (
 @@ -207,30 +196,24 @@ type sha224Hash struct {
  	out [224 / 8]byte
  }
- 
+
 -func (h *sha224Hash) noescapeCtx() *C.GO_SHA256_CTX {
 -	return (*C.GO_SHA256_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7013,7 +7013,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha224Hash) Size() int            { return 224 / 8 }
 +func (h *sha224Hash) BlockSize() int       { return 64 }
 +func (h *sha224Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
- 
+
  func (h *sha224Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA224_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA224_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7021,7 +7021,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
- 
+
 -func (h0 *sha224Hash) sum(dst []byte) []byte {
 +func (h0 *sha224Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7032,12 +7032,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
- 
+
  // NewSHA256 returns a new SHA256 hash.
 @@ -245,30 +228,24 @@ type sha256Hash struct {
  	out [256 / 8]byte
  }
- 
+
 -func (h *sha256Hash) noescapeCtx() *C.GO_SHA256_CTX {
 -	return (*C.GO_SHA256_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7052,7 +7052,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha256Hash) Size() int            { return 256 / 8 }
 +func (h *sha256Hash) BlockSize() int       { return 64 }
 +func (h *sha256Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
- 
+
  func (h *sha256Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA256_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA256_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7060,7 +7060,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
- 
+
 -func (h0 *sha256Hash) sum(dst []byte) []byte {
 +func (h0 *sha256Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7071,12 +7071,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
- 
+
  const (
 @@ -382,30 +359,24 @@ type sha384Hash struct {
  	out [384 / 8]byte
  }
- 
+
 -func (h *sha384Hash) noescapeCtx() *C.GO_SHA512_CTX {
 -	return (*C.GO_SHA512_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7091,7 +7091,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha384Hash) Size() int            { return 384 / 8 }
 +func (h *sha384Hash) BlockSize() int       { return 128 }
 +func (h *sha384Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
- 
+
  func (h *sha384Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA384_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA384_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7099,7 +7099,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
- 
+
 -func (h0 *sha384Hash) sum(dst []byte) []byte {
 +func (h0 *sha384Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7110,12 +7110,12 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
- 
+
  // NewSHA512 returns a new SHA512 hash.
 @@ -420,30 +391,24 @@ type sha512Hash struct {
  	out [512 / 8]byte
  }
- 
+
 -func (h *sha512Hash) noescapeCtx() *C.GO_SHA512_CTX {
 -	return (*C.GO_SHA512_CTX)(noescape(unsafe.Pointer(&h.ctx)))
 -}
@@ -7130,7 +7130,7 @@ index cf82f3f64f..0b55cedc91 100644
 +func (h *sha512Hash) Size() int            { return 512 / 8 }
 +func (h *sha512Hash) BlockSize() int       { return 128 }
 +func (h *sha512Hash) Sum(in []byte) []byte { return append(in, h.sum()...) }
- 
+
  func (h *sha512Hash) Write(p []byte) (int, error) {
 -	if len(p) > 0 && C._goboringcrypto_SHA512_Update(h.noescapeCtx(), unsafe.Pointer(&*addr(p)), C.size_t(len(p))) == 0 {
 +	if len(p) > 0 && C._goboringcrypto_SHA512_Update(&h.ctx, unsafe.Pointer(&p[0]), C.size_t(len(p))) == 0 {
@@ -7138,7 +7138,7 @@ index cf82f3f64f..0b55cedc91 100644
  	}
  	return len(p), nil
  }
- 
+
 -func (h0 *sha512Hash) sum(dst []byte) []byte {
 +func (h0 *sha512Hash) sum() []byte {
  	h := *h0 // make copy so future Write+Sum is valid
@@ -7149,7 +7149,7 @@ index cf82f3f64f..0b55cedc91 100644
 -	return append(dst, h.out[:]...)
 +	return h.out[:]
  }
- 
+
  type sha512Ctx struct {
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
 index 89a7c86c41..f4f12ecee2 100644

--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -2348,24 +2348,24 @@ index 8734dd03c1..22a104f338 100644
  	} else {
  		testCurve = elliptic.P384()
 diff --git a/src/go.mod b/src/go.mod
-index 4697da201c..0a5e32e27a 100644
+index 4697da201c..a3891edd78 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.20
  
  require (
-+	github.com/golang-fips/openssl-fips v0.0.0-20230323210700-e1541889d8a8
++	github.com/golang-fips/openssl-fips v0.0.0-20230714114059-9051f24728fe
  	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
  	golang.org/x/net v0.4.1-0.20230214201333-88ed8ca3307d
  )
 diff --git a/src/go.sum b/src/go.sum
-index 625f2070b3..fb6828ce41 100644
+index 625f2070b3..2e984ad481 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl-fips v0.0.0-20230323210700-e1541889d8a8 h1:nY4kLp8xhBuVWF5mqsluydyZnJzW2FELBC+A4EEtu1o=
-+github.com/golang-fips/openssl-fips v0.0.0-20230323210700-e1541889d8a8/go.mod h1:V2IU8imz/VkScnIbTOrdYsZ5R88ZFypCE0LzhRJ3HsI=
++github.com/golang-fips/openssl-fips v0.0.0-20230714114059-9051f24728fe h1:Zr44HT3VYwYIkT72fyvaqWZN+sO2Saw++e+6PaXapN0=
++github.com/golang-fips/openssl-fips v0.0.0-20230714114059-9051f24728fe/go.mod h1:V2IU8imz/VkScnIbTOrdYsZ5R88ZFypCE0LzhRJ3HsI=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
  golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
  golang.org/x/net v0.4.1-0.20230214201333-88ed8ca3307d h1:KHU/KRz6+/yWyRHEC24m7T5gou5VSh62duch955ktBY=
@@ -5631,10 +5631,10 @@ index 0000000000..df4ebe3297
 +}
 diff --git a/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl_port_ecdh.c b/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl_port_ecdh.c
 new file mode 100644
-index 0000000000..abdee81a91
+index 0000000000..8205b040c5
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl-fips/openssl/openssl_port_ecdh.c
-@@ -0,0 +1,334 @@
+@@ -0,0 +1,342 @@
 +// +build linux
 +// +build !android
 +// +build !no_openssl
@@ -5676,6 +5676,8 @@ index 0000000000..abdee81a91
 +		return 0;
 +
 +	*result = malloc(len);
++	if (!*result)
++		return 0;
 +
 +	len = _goboringcrypto_EC_POINT_point2oct(group, point,
 +						 GO_POINT_CONVERSION_UNCOMPRESSED,
@@ -5760,14 +5762,18 @@ index 0000000000..abdee81a91
 +		if (!priv)
 +			goto err;
 +
-+		if (!_goboringcrypto_internal_OSSL_PARAM_BLD_push_BN(bld, "priv", priv))
++		if (!_goboringcrypto_internal_OSSL_PARAM_BLD_push_BN(bld, "priv", priv)) {
++			_goboringcrypto_BN_clear_free(priv);
 +			goto err;
++		}
 +
 +		params = _goboringcrypto_internal_OSSL_PARAM_BLD_to_param(bld);
-+		_goboringcrypto_BN_free(priv);
-+		if (!params)
++		if (!params) {
++			_goboringcrypto_BN_clear_free(priv);
 +			goto err;
++		}
 +
++		_goboringcrypto_BN_clear_free(priv);
 +		selection = GO_EVP_PKEY_KEYPAIR;
 +	} else {
 +		if (!_goboringcrypto_internal_OSSL_PARAM_BLD_push_octet_string(bld, "pub", bytes, len))
@@ -5797,7 +5803,7 @@ index 0000000000..abdee81a91
 +	return result;
 +}
 +
-+DEFINEFUNCINTERNAL(void, OPENSSL_free, (void *addr), (addr))
++DEFINEFUNCINTERNAL(void, CRYPTO_free, (void *addr, const char *file, int line), (addr, file, line))
 +
 +size_t
 +_goboringcrypto_EVP_PKEY_get1_encoded_ecdh_public_key(GO_EVP_PKEY *pkey,
@@ -5812,10 +5818,11 @@ index 0000000000..abdee81a91
 +
 +	*result = malloc(len);
 +	if (!*result) {
-+		_goboringcrypto_internal_OPENSSL_free(res);
++		_goboringcrypto_internal_CRYPTO_free(res, __FILE__, __LINE__);
 +		return 0;
 +	}
 +	memcpy(*result, res, len);
++	_goboringcrypto_internal_CRYPTO_free(res, __FILE__, __LINE__);
 +	return len;
 +}
 +
@@ -5852,6 +5859,7 @@ index 0000000000..abdee81a91
 +err:
 +	_goboringcrypto_EC_GROUP_free(group);
 +	_goboringcrypto_EC_POINT_free(point);
++	_goboringcrypto_BN_free(priv);
 +	free(pub);
 +	return result;
 +}
@@ -5875,10 +5883,10 @@ index 0000000000..abdee81a91
 +		if (!priv)
 +			goto err;
 +		if (_goboringcrypto_EC_KEY_set_private_key(key, priv) != 1) {
-+			_goboringcrypto_BN_free(priv);
++			_goboringcrypto_BN_clear_free(priv);
 +			goto err;
 +		}
-+		_goboringcrypto_BN_free(priv);
++		_goboringcrypto_BN_clear_free(priv);
 +	} else {
 +		const EC_GROUP *group = _goboringcrypto_EC_KEY_get0_group(key);
 +		EC_POINT *pub;
@@ -7144,11 +7152,11 @@ index cf82f3f64f..0b55cedc91 100644
  
  type sha512Ctx struct {
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 89a7c86c41..d3e88755be 100644
+index 89a7c86c41..f4f12ecee2 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,6 @@
-+# github.com/golang-fips/openssl-fips v0.0.0-20230323210700-e1541889d8a8
++# github.com/golang-fips/openssl-fips v0.0.0-20230714114059-9051f24728fe
 +## explicit; go 1.18
 +github.com/golang-fips/openssl-fips/openssl
  # golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a


### PR DESCRIPTION
Update to Go 1.20.6 and update openssl bindings to 9051f24728fe to fix memory leak.