### PR TITLE
Fix OpenSSL Runtime Check

### DIFF
--- a/src/crypto/internal/boring/boring.go
+++ b/src/crypto/internal/boring/boring.go
@@ -34,9 +34,6 @@ const (
 	OPENSSL_VERSION_3_0_0 = uint64(C.ulong(0x30000000))
 )
 
-func init() {
-	strictFIPSOpenSSLRuntimeCheck()
-}
 
 // Enabled controls whether FIPS crypto is enabled.
 var enabled = false
@@ -58,6 +55,7 @@ func init() {
 
 	// Check if we can `dlopen` OpenSSL
 	if C._goboringcrypto_DLOPEN_OPENSSL() == C.NULL {
+		strictFIPSOpenSSLRuntimeCheck()
 		return
 	}
 

--- a/src/crypto/internal/boring/strict_fips.go
+++ b/src/crypto/internal/boring/strict_fips.go
@@ -11,7 +11,7 @@ import (
 var isStrictFIPS bool = true
 
 func strictFIPSOpenSSLRuntimeCheck() {
-	if hostFIPSModeEnabled() && !Enabled() {
+	if hostFIPSModeEnabled() {
 		fmt.Fprintln(os.Stderr, "FIPS mode is enabled, but the required OpenSSL backend is unavailable")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This check can not happen before the openssl
backend is initialized.