### PR TITLE
Backport of fix to CVE 2023-45285 for Go1.19

### DIFF
--- a/patches/007-fix-CVE-2023-45285.patch
+++ b/patches/007-fix-CVE-2023-45285.patch
@@ -1,0 +1,92 @@
+From 268bce130cc80693adaa9b8d6401ceb76e901c81 Mon Sep 17 00:00:00 2001
+From: Archana Ravindar <aravinda@redhat.com>
+Date: Thu, 8 Feb 2024 22:55:41 +0530
+Subject: [PATCH] fix CVE 2023-45285
+
+---
+ src/cmd/go/internal/vcs/vcs.go                | 25 ++++++++++++----
+ .../script/mod_insecure_issue63845.txt        | 29 +++++++++++++++++++
+ 2 files changed, 48 insertions(+), 6 deletions(-)
+ create mode 100644 src/cmd/go/testdata/script/mod_insecure_issue63845.txt
+
+diff --git a/src/cmd/go/internal/vcs/vcs.go b/src/cmd/go/internal/vcs/vcs.go
+index 4f16bef90c..974a29b505 100644
+--- a/src/cmd/go/internal/vcs/vcs.go
++++ b/src/cmd/go/internal/vcs/vcs.go
+@@ -1151,19 +1151,32 @@ func repoRootFromVCSPaths(importPath string, security web.SecurityMode, vcsPaths
+ 		if !srv.schemelessRepo {
+ 			repoURL = match["repo"]
+ 		} else {
+-			scheme := vcs.Scheme[0] // default to first scheme
+ 			repo := match["repo"]
+-			if vcs.PingCmd != "" {
+-				// If we know how to test schemes, scan to find one.
++			scheme, err := func() (string, error) {
+ 				for _, s := range vcs.Scheme {
+ 					if security == web.SecureOnly && !vcs.isSecureScheme(s) {
+ 						continue
+ 					}
+-					if vcs.Ping(s, repo) == nil {
+-						scheme = s
+-						break
++
++					// If we know how to ping URL schemes for this VCS,
++					// check that this repo works.
++					// Otherwise, default to the first scheme
++					// that meets the requested security level.
++					if vcs.PingCmd == "" {
++						return s, nil
++					}
++					if err := vcs.Ping(s, repo); err == nil {
++						return s, nil
+ 					}
+ 				}
++				securityFrag := ""
++				if security == web.SecureOnly {
++					securityFrag = "secure "
++				}
++				return "", fmt.Errorf("no %sprotocol found for repository", securityFrag)
++			}()
++			if err != nil {
++				return nil, err
+ 			}
+ 			repoURL = scheme + "://" + repo
+ 		}
+diff --git a/src/cmd/go/testdata/script/mod_insecure_issue63845.txt b/src/cmd/go/testdata/script/mod_insecure_issue63845.txt
+new file mode 100644
+index 0000000000..84d85a7985
+--- /dev/null
++++ b/src/cmd/go/testdata/script/mod_insecure_issue63845.txt
+@@ -0,0 +1,29 @@
++# Regression test for https://go.dev/issue/63845:
++# If 'git ls-remote' fails for all secure protocols,
++# we should fail instead of falling back to an arbitrary protocol.
++#
++# Note that this test does not use the local vcweb test server
++# (vcs-test.golang.org), because the hook for redirecting to that
++# server bypasses the "ping to determine protocol" logic
++# in cmd/go/internal/vcs.
++
++[!net] skip
++[!exec:git] skip
++[short] skip 'tries to access a nonexistent external Git repo'
++
++env GOPRIVATE=golang.org
++env CURLOPT_TIMEOUT_MS=100
++env GIT_SSH_COMMAND=false
++
++! go get -x golang.org/nonexist.git@latest
++stderr '^git ls-remote https://golang.org/nonexist$'
++stderr '^git ls-remote git\+ssh://golang.org/nonexist'
++stderr '^git ls-remote ssh://golang.org/nonexist$'
++! stderr 'git://'
++stderr '^go: golang.org/nonexist.git@latest: no secure protocol found for repository$'
++
++-- go.mod --
++module example
++
++go 1.19
++
+-- 
+2.31.1
+


### PR DESCRIPTION
Backporting the following fix to CVE 2023-45285 
The two lines in the .txt file needed to be changed to work with the older style of commands in TestScripts/ testing engine
https://go-review.googlesource.com/c/go/+/540257/3/src/cmd/go/testdata/script/mod_insecure_issue63845.txt