### PR TITLE
fix linkage issue in RH builds

### DIFF
--- a/patches/015-fix-linkage.patch
+++ b/patches/015-fix-linkage.patch
@@ -1,0 +1,15 @@
+diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
+index 32e59b446a..b55f29298b 100644
+--- a/src/cmd/dist/build.go
++++ b/src/cmd/dist/build.go
+@@ -1309,7 +1309,9 @@ func toolenv() []string {
+ 		// we disable cgo to get static binaries for cmd/go and cmd/pprof,
+ 		// so that they work on systems without the same dynamic libraries
+ 		// as the original build system.
+-		env = append(env, "CGO_ENABLED=0")
++		//
++		// Setting CGO_ENABLED to 0 prevents cmd/go and the like from linking with vendored openssl symbols.
++		// env = append(env, "CGO_ENABLED=0")
+ 	}
+ 	if isRelease || os.Getenv("GO_BUILDER_NAME") != "" {
+ 		// Add -trimpath for reproducible builds of releases.


### PR DESCRIPTION
go binary (tested with v1.21.7 on Oracle Linux) seems to be missing vendored openssl patches. 
```
$ go tool nm $(which go) | grep -i openssl-fips
$ 
```
The above command returns nothing. Derek suggested that https://go-review.googlesource.com/c/go/+/454836 might be the reason for this. 

I wanted to try a smaller change-set and so i think setting toolenv to empty string should work. I tried a make.bash and it worked and linkage is fine post that. 

fixes https://github.com/golang-fips/go/issues/186

First time submitting a PR here, so please let me know if any changes are required. 