### PR TITLE
Backport change https://go-review.googlesource.com/c/go/+/554615 to Go1.22

### DIFF
--- a/patches/015-fix-crashdumpallthreads.patch
+++ b/patches/015-fix-crashdumpallthreads.patch
@@ -1,0 +1,61 @@
+From 8d2ec6b3704753e17dbafbc2407d7f4c808fd57f Mon Sep 17 00:00:00 2001
+From: Archana Ravindar <aravinda@redhat.com>
+Date: Wed, 15 May 2024 18:15:24 +0530
+Subject: [PATCH 1/1] create a patch to increase sleep time
+
+---
+ src/runtime/signal_unix.go | 29 ++++++++++++++++++++++++-----
+ 1 file changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/src/runtime/signal_unix.go b/src/runtime/signal_unix.go
+index 84391d58ed..6b83bb838b 100644
+--- a/src/runtime/signal_unix.go
++++ b/src/runtime/signal_unix.go
+@@ -753,6 +753,9 @@ func sighandler(sig uint32, info *siginfo, ctxt unsafe.Pointer, gp *g) {
+ 
+ 	if docrash {
+ 		isCrashThread := false
++		var crashSleepMicros uint32 = 5000
++		var watchdogTimeoutMicros uint32 = 2000 * crashSleepMicros
++
+ 		if crashing.CompareAndSwap(0, 1) {
+ 			isCrashThread = true
+ 		} else {
+@@ -775,13 +778,29 @@ func sighandler(sig uint32, info *siginfo, ctxt unsafe.Pointer, gp *g) {
+ 			raiseproc(_SIGQUIT)
+ 		}
+ 		if isCrashThread {
+-			i := 0
+-			for (crashing.Load() < mcount()-int32(extraMLength.Load())) && i < 10 {
+-				i++
+-				usleep(500 * 1000)
++			// Sleep for short intervals so that we can crash quickly after all ms have received SIGQUIT.
++			// Reset the timer whenever we see more ms received SIGQUIT
++			// to make it have enough time to crash (see issue #64752).
++			timeout := watchdogTimeoutMicros
++			maxCrashing := crashing.Load()
++			for timeout > 0 && (crashing.Load() < mcount()-int32(extraMLength.Load())) {
++				usleep(crashSleepMicros)
++				timeout -= crashSleepMicros
++
++				if c := crashing.Load(); c > maxCrashing {
++					// We make progress, so reset the watchdog timeout
++					maxCrashing = c
++					timeout = watchdogTimeoutMicros
++				}
+ 			}
+ 		} else {
+-			usleep(5 * 1000 * 1000)
++			maxCrashing := int32(0)
++			c := crashing.Load()
++			for c > maxCrashing {
++				maxCrashing = c
++				usleep(watchdogTimeoutMicros)
++				c = crashing.Load()
++			}
+ 		}
+ 		printDebugLog()
+ 		crash()
+-- 
+2.44.0
+

--- a/patches/016-fix-crashdumpallthreads.patch
+++ b/patches/016-fix-crashdumpallthreads.patch
@@ -1,4 +1,3 @@
-From 8d2ec6b3704753e17dbafbc2407d7f4c808fd57f Mon Sep 17 00:00:00 2001
 From: Archana Ravindar <aravinda@redhat.com>
 Date: Wed, 15 May 2024 18:15:24 +0530
 Subject: [PATCH 1/1] create a patch to increase sleep time


### PR DESCRIPTION
- Backport change https://go-review.googlesource.com/c/go/+/554615 to Go1.22. This fix increases sleep time
long enough to see that SIGQUIT is passed on to all threads and avoids CrashDumpAllThreads failure on s390x
- Fixes: GT-243