### PR TITLE
backport of linkage fix to v1.21

### DIFF
--- a/patches/003-fix-linkage.patch
+++ b/patches/003-fix-linkage.patch
@@ -1,0 +1,15 @@
+diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
+index 8973a87168..4968e6c923 100644
+--- a/src/cmd/dist/build.go
++++ b/src/cmd/dist/build.go
+@@ -1315,7 +1315,9 @@ func toolenv() []string {
+ 		// we disable cgo to get static binaries for cmd/go and cmd/pprof,
+ 		// so that they work on systems without the same dynamic libraries
+ 		// as the original build system.
+-		env = append(env, "CGO_ENABLED=0")
++		//
++		// Setting CGO_ENABLED to 0 prevents cmd/go and the like from linking with vendored openssl symbols.
++		// env = append(env, "CGO_ENABLED=0")
+ 	}
+ 	if isRelease || os.Getenv("GO_BUILDER_NAME") != "" {
+ 		// Add -trimpath for reproducible builds of releases.


### PR DESCRIPTION
https://github.com/golang-fips/go/pull/190 fixed a linkage issue in RH builds.

This PR aims to backport that fix to the go1.21-fips-release branch