### PR TITLE
Include commit that removes EC_KEY* functions usage to enforce FIPS restrictions (PR #143) 

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "github.com/golang-fips/go": "go1.20-fips-release",
     "github.com/golang-fips/openssl-fips": "b175be2ccd46683a51cba60a9a2087b09593317d",
-    "github.com/golang/go": "go1.20.11"
+    "github.com/golang/go": "go1.20.12"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "github.com/golang-fips/go": "go1.20-fips-release",
-    "github.com/golang-fips/openssl-fips": "b175be2ccd46683a51cba60a9a2087b09593317d",
+    "github.com/golang-fips/openssl-fips": "a10e615bfd26452f55725ade970bb87b4145483d",
     "github.com/golang/go": "go1.20.12"
 }


### PR DESCRIPTION
Include commit https://github.com/golang-fips/openssl/pull/143 (hash: a10e615bfd26452f55725ade970bb87b4145483d) that removes usage of EC_KEY* functions to enforce FIPS restrictions
