### PR TITLE
Rebase to Go1.22.5 to fix CVE-2024-24791

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "github.com/golang-fips/go": "main",
   "github.com/golang-fips/openssl": "61a53ab338d5f1657c6fe5d856d24528bfdd731d",
-  "github.com/golang/go": "go1.22.4"
+  "github.com/golang/go": "go1.22.5"
 }


### PR DESCRIPTION
rebase to pick latest Go1.22 release 
contains fix for CVE-2024-24791 and Go issue https://go.dev/issue/67555.