### PR TITLE
Added skip pkcs test patch to avoid CI error on ubi8 for PR 213

### DIFF
--- a/patches/006-skip-pkcs-test.patch
+++ b/patches/006-skip-pkcs-test.patch
@@ -1,0 +1,15 @@
+diff --git a/src/crypto/rsa/pkcs1v15_test.go b/src/crypto/rsa/pkcs1v15_test.go
+index f6afc363ea..c164ec5706 100644
+--- a/src/crypto/rsa/pkcs1v15_test.go
++++ b/src/crypto/rsa/pkcs1v15_test.go
+@@ -245,6 +245,10 @@ func TestVerifyPKCS1v15(t *testing.T) {
+ }
+ 
+ func TestOverlongMessagePKCS1v15(t *testing.T) {
++	// OpenSSL now returns a random string instead of an error
++	if boring.Enabled() {
++		t.Skip("Not relevant in boring mode")
++	}
+ 	ciphertext := decodeBase64("fjOVdirUzFoLlukv80dBllMLjXythIf22feqPrNo0YoIjzyzyoMFiLjAc/Y4krkeZ11XFThIrEvw\nkRiZcCq5ng==")
+ 	_, err := DecryptPKCS1v15(nil, rsaPrivateKey, ciphertext)
+ 	if err == nil {


### PR DESCRIPTION

related to CVE 2023-45290