### PR TITLE
Backport of fix for CVE-2024-24790 to Go1.20

### DIFF
--- a/patches/007-fix-CVE-2024-24790.patch
+++ b/patches/007-fix-CVE-2024-24790.patch
@@ -1,0 +1,181 @@
+From 9d1e801f26574fb8b8240f58f8b51652ff2f9d7e Mon Sep 17 00:00:00 2001
+From: Archana Ravindar <aravinda@redhat.com>
+Date: Tue, 30 Jul 2024 11:30:59 +0530
+Subject: [PATCH] backport fix for Golang issue #67680 into Go1.20 Fixes
+ CVE-2024-24790
+
+---
+ src/net/netip/netip.go      | 26 ++++++++++++++++++++++-
+ src/net/netip/netip_test.go | 42 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 67 insertions(+), 1 deletion(-)
+
+diff --git a/src/net/netip/netip.go b/src/net/netip/netip.go
+index ec9266d583..7d1b1af5f4 100644
+--- a/src/net/netip/netip.go
++++ b/src/net/netip/netip.go
+@@ -508,6 +508,10 @@ func (ip Addr) hasZone() bool {
+ 
+ // IsLinkLocalUnicast reports whether ip is a link-local unicast address.
+ func (ip Addr) IsLinkLocalUnicast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
++
+ 	// Dynamic Configuration of IPv4 Link-Local Addresses
+ 	// https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
+ 	if ip.Is4() {
+@@ -523,6 +527,10 @@ func (ip Addr) IsLinkLocalUnicast() bool {
+ 
+ // IsLoopback reports whether ip is a loopback address.
+ func (ip Addr) IsLoopback() bool {
++        if ip.Is4In6() {
++                ip = ip.Unmap()
++        }
++
+ 	// Requirements for Internet Hosts -- Communication Layers (3.2.1.3 Addressing)
+ 	// https://datatracker.ietf.org/doc/html/rfc1122#section-3.2.1.3
+ 	if ip.Is4() {
+@@ -538,6 +546,10 @@ func (ip Addr) IsLoopback() bool {
+ 
+ // IsMulticast reports whether ip is a multicast address.
+ func (ip Addr) IsMulticast() bool {
++        if ip.Is4In6() {
++                ip = ip.Unmap()
++        }
++
+ 	// Host Extensions for IP Multicasting (4. HOST GROUP ADDRESSES)
+ 	// https://datatracker.ietf.org/doc/html/rfc1112#section-4
+ 	if ip.Is4() {
+@@ -556,7 +568,7 @@ func (ip Addr) IsMulticast() bool {
+ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 	// IPv6 Addressing Architecture (2.7.1. Pre-Defined Multicast Addresses)
+ 	// https://datatracker.ietf.org/doc/html/rfc4291#section-2.7.1
+-	if ip.Is6() {
++	if ip.Is6() && !ip.Is4In6() {
+ 		return ip.v6u16(0)&0xff0f == 0xff01
+ 	}
+ 	return false // zero value
+@@ -564,6 +576,10 @@ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 
+ // IsLinkLocalMulticast reports whether ip is a link-local multicast address.
+ func (ip Addr) IsLinkLocalMulticast() bool {
++	if ip.Is4In6() {
++                ip = ip.Unmap()
++        }
++
+ 	// IPv4 Multicast Guidelines (4. Local Network Control Block (224.0.0/24))
+ 	// https://datatracker.ietf.org/doc/html/rfc5771#section-4
+ 	if ip.Is4() {
+@@ -587,6 +603,10 @@ func (ip Addr) IsLinkLocalMulticast() bool {
+ //
+ // For reference, see RFC 1122, RFC 4291, and RFC 4632.
+ func (ip Addr) IsGlobalUnicast() bool {
++	if ip.Is4In6() {
++                ip = ip.Unmap()
++        }
++
+ 	if ip.z == z0 {
+ 		// Invalid or zero-value.
+ 		return false
+@@ -609,6 +629,10 @@ func (ip Addr) IsGlobalUnicast() bool {
+ // ip is in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, or fc00::/7. This is the
+ // same as net.IP.IsPrivate.
+ func (ip Addr) IsPrivate() bool {
++	if ip.Is4In6() {
++                ip = ip.Unmap()
++        }
++
+ 	// Match the stdlib's IsPrivate logic.
+ 	if ip.Is4() {
+ 		// RFC 1918 allocates 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16 as
+diff --git a/src/net/netip/netip_test.go b/src/net/netip/netip_test.go
+index b915b240ea..31f042aa09 100644
+--- a/src/net/netip/netip_test.go
++++ b/src/net/netip/netip_test.go
+@@ -594,6 +594,9 @@ func TestIPProperties(t *testing.T) {
+ 		private4b = mustIP("172.16.0.1")
+ 		private4c = mustIP("192.168.1.1")
+ 		private6  = mustIP("fd00::1")
++		private6mapped4a = mustIP("::ffff:10.0.0.1")
++		private6mapped4b = mustIP("::ffff:172.16.0.1")
++		private6mapped4c = mustIP("::ffff:192.168.1.1")
+ 	)
+ 
+ 	tests := []struct {
+@@ -617,6 +620,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:            unicast4,
+ 			globalUnicast: true,
+ 		},
++		{
++			name:          "unicast v6 mapped v4Addr",
++			ip:            AddrFrom16(unicast4.As16()),
++			globalUnicast: true,
++		},
+ 		{
+ 			name:          "unicast v6Addr",
+ 			ip:            unicast6,
+@@ -638,6 +646,12 @@ func TestIPProperties(t *testing.T) {
+ 			linkLocalMulticast: true,
+ 			multicast:          true,
+ 		},
++		{
++			name:               "multicast v6 mapped v4Addr",
++			ip:                 AddrFrom16(multicast4.As16()),
++			linkLocalMulticast: true,
++			multicast:          true,
++		},
+ 		{
+ 			name:               "multicast v6Addr",
+ 			ip:                 multicast6,
+@@ -655,6 +669,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:               llu4,
+ 			linkLocalUnicast: true,
+ 		},
++		{
++			name:             "link-local unicast v6 mapped v4Addr",
++			ip:               AddrFrom16(llu4.As16()),
++			linkLocalUnicast: true,
++		},
+ 		{
+ 			name:             "link-local unicast v6Addr",
+ 			ip:               llu6,
+@@ -680,6 +699,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:       loopback6,
+ 			loopback: true,
+ 		},
++		{
++			name:     "loopback v6 mapped v4Addr",
++			ip:       AddrFrom16(IPv6Loopback().As16()),
++			loopback: true,
++		},
+ 		{
+ 			name:                    "interface-local multicast v6Addr",
+ 			ip:                      ilm6,
+@@ -716,6 +740,24 @@ func TestIPProperties(t *testing.T) {
+ 			globalUnicast: true,
+ 			private:       true,
+ 		},
++		{
++			name:          "private v6 mapped v4Addr 10/8",
++			ip:            private6mapped4a,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 172.16/12",
++			ip:            private6mapped4b,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 192.168/16",
++			ip:            private6mapped4c,
++			globalUnicast: true,
++			private:       true,
++		},
+ 		{
+ 			name:        "unspecified v4Addr",
+ 			ip:          IPv4Unspecified(),
+-- 
+2.39.3
+

--- a/patches/007-fix-CVE-2024-24790.patch
+++ b/patches/007-fix-CVE-2024-24790.patch
@@ -1,14 +1,28 @@
-From 9d1e801f26574fb8b8240f58f8b51652ff2f9d7e Mon Sep 17 00:00:00 2001
+From bbbb813c9e4d0c3102b2dbe2723cc67e5bc0a6fd Mon Sep 17 00:00:00 2001
 From: Archana Ravindar <aravinda@redhat.com>
-Date: Tue, 30 Jul 2024 11:30:59 +0530
-Subject: [PATCH] backport fix for Golang issue #67680 into Go1.20 Fixes
- CVE-2024-24790
+Date: Tue, 30 Jul 2024 13:16:44 +0530
+Subject: [PATCH] backport of fix to CVE-2024-24790 to Go1.20
 
 ---
- src/net/netip/netip.go      | 26 ++++++++++++++++++++++-
- src/net/netip/netip_test.go | 42 +++++++++++++++++++++++++++++++++++++
- 2 files changed, 67 insertions(+), 1 deletion(-)
+ src/net/netip/inlining_test.go |  3 ---
+ src/net/netip/netip.go         | 26 ++++++++++++++++++++-
+ src/net/netip/netip_test.go    | 42 ++++++++++++++++++++++++++++++++++
+ 3 files changed, 67 insertions(+), 4 deletions(-)
 
+diff --git a/src/net/netip/inlining_test.go b/src/net/netip/inlining_test.go
+index b521eeebfd..a473ad4bff 100644
+--- a/src/net/netip/inlining_test.go
++++ b/src/net/netip/inlining_test.go
+@@ -36,9 +36,6 @@ func TestInlining(t *testing.T) {
+ 		"Addr.Is4",
+ 		"Addr.Is4In6",
+ 		"Addr.Is6",
+-		"Addr.IsLoopback",
+-		"Addr.IsMulticast",
+-		"Addr.IsInterfaceLocalMulticast",
+ 		"Addr.IsValid",
+ 		"Addr.IsUnspecified",
+ 		"Addr.Less",
 diff --git a/src/net/netip/netip.go b/src/net/netip/netip.go
 index ec9266d583..7d1b1af5f4 100644
 --- a/src/net/netip/netip.go
@@ -177,5 +191,5 @@ index b915b240ea..31f042aa09 100644
  			name:        "unspecified v4Addr",
  			ip:          IPv4Unspecified(),
 -- 
-2.39.3
+2.45.2
 


### PR DESCRIPTION
taken from https://go-review.googlesource.com/c/go/+/590316
fixes CVE-2024-24790