### PR TITLE
Backport of fix for CVE 2024-24790 to Go1.19

### DIFF
--- a/patches/010-fix-CVE-2024-24790.patch
+++ b/patches/010-fix-CVE-2024-24790.patch
@@ -1,0 +1,213 @@
+From 923c6a0066bf99b07599e225a94fafbdec466ba5 Mon Sep 17 00:00:00 2001
+From: Archana Ravindar <aravinda@redhat.com>
+Date: Wed, 31 Jul 2024 14:12:32 +0530
+Subject: [PATCH] Backport of fix for CVE 2024-24790 to Go1.19
+ https://go-review.googlesource.com/c/go/+/590315
+
+---
+ src/net/netip/inlining_test.go |  3 --
+ src/net/netip/netip.go         | 21 ++++++++++++--
+ src/net/netip/netip_test.go    | 53 ++++++++++++++++++++++++++++++----
+ 3 files changed, 67 insertions(+), 10 deletions(-)
+
+diff --git a/src/net/netip/inlining_test.go b/src/net/netip/inlining_test.go
+index 52991bee8c..41d0344497 100644
+--- a/src/net/netip/inlining_test.go
++++ b/src/net/netip/inlining_test.go
+@@ -36,9 +36,6 @@ func TestInlining(t *testing.T) {
+ 		"Addr.Is4",
+ 		"Addr.Is4In6",
+ 		"Addr.Is6",
+-		"Addr.IsLoopback",
+-		"Addr.IsMulticast",
+-		"Addr.IsInterfaceLocalMulticast",
+ 		"Addr.IsValid",
+ 		"Addr.IsUnspecified",
+ 		"Addr.Less",
+diff --git a/src/net/netip/netip.go b/src/net/netip/netip.go
+index bb83371a55..0bbbf88852 100644
+--- a/src/net/netip/netip.go
++++ b/src/net/netip/netip.go
+@@ -515,6 +515,9 @@ func (ip Addr) hasZone() bool {
+ 
+ // IsLinkLocalUnicast reports whether ip is a link-local unicast address.
+ func (ip Addr) IsLinkLocalUnicast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Dynamic Configuration of IPv4 Link-Local Addresses
+ 	// https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
+ 	if ip.Is4() {
+@@ -530,6 +533,9 @@ func (ip Addr) IsLinkLocalUnicast() bool {
+ 
+ // IsLoopback reports whether ip is a loopback address.
+ func (ip Addr) IsLoopback() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Requirements for Internet Hosts -- Communication Layers (3.2.1.3 Addressing)
+ 	// https://datatracker.ietf.org/doc/html/rfc1122#section-3.2.1.3
+ 	if ip.Is4() {
+@@ -545,6 +551,9 @@ func (ip Addr) IsLoopback() bool {
+ 
+ // IsMulticast reports whether ip is a multicast address.
+ func (ip Addr) IsMulticast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Host Extensions for IP Multicasting (4. HOST GROUP ADDRESSES)
+ 	// https://datatracker.ietf.org/doc/html/rfc1112#section-4
+ 	if ip.Is4() {
+@@ -563,7 +572,7 @@ func (ip Addr) IsMulticast() bool {
+ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 	// IPv6 Addressing Architecture (2.7.1. Pre-Defined Multicast Addresses)
+ 	// https://datatracker.ietf.org/doc/html/rfc4291#section-2.7.1
+-	if ip.Is6() {
++	if ip.Is6() && !ip.Is4In6() {
+ 		return ip.v6u16(0)&0xff0f == 0xff01
+ 	}
+ 	return false // zero value
+@@ -571,6 +580,9 @@ func (ip Addr) IsInterfaceLocalMulticast() bool {
+ 
+ // IsLinkLocalMulticast reports whether ip is a link-local multicast address.
+ func (ip Addr) IsLinkLocalMulticast() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// IPv4 Multicast Guidelines (4. Local Network Control Block (224.0.0/24))
+ 	// https://datatracker.ietf.org/doc/html/rfc5771#section-4
+ 	if ip.Is4() {
+@@ -598,7 +610,9 @@ func (ip Addr) IsGlobalUnicast() bool {
+ 		// Invalid or zero-value.
+ 		return false
+ 	}
+-
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Match package net's IsGlobalUnicast logic. Notably private IPv4 addresses
+ 	// and ULA IPv6 addresses are still considered "global unicast".
+ 	if ip.Is4() && (ip == IPv4Unspecified() || ip == AddrFrom4([4]byte{255, 255, 255, 255})) {
+@@ -616,6 +630,9 @@ func (ip Addr) IsGlobalUnicast() bool {
+ // ip is in 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, or fc00::/7. This is the
+ // same as net.IP.IsPrivate.
+ func (ip Addr) IsPrivate() bool {
++	if ip.Is4In6() {
++		ip = ip.Unmap()
++	}
+ 	// Match the stdlib's IsPrivate logic.
+ 	if ip.Is4() {
+ 		// RFC 1918 allocates 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16 as
+diff --git a/src/net/netip/netip_test.go b/src/net/netip/netip_test.go
+index 74dcc974f8..0d7025cef2 100644
+--- a/src/net/netip/netip_test.go
++++ b/src/net/netip/netip_test.go
+@@ -550,15 +550,18 @@ func TestIPProperties(t *testing.T) {
+ 		lluZone6 = mustIP("fe80::1%eth0")
+ 
+ 		loopback4 = mustIP("127.0.0.1")
+-		loopback6 = mustIP("::1")
++	        loopback6 = mustIP("::1")
+ 
+ 		ilm6     = mustIP("ff01::1")
+ 		ilmZone6 = mustIP("ff01::1%eth0")
+ 
+-		private4a = mustIP("10.0.0.1")
+-		private4b = mustIP("172.16.0.1")
+-		private4c = mustIP("192.168.1.1")
+-		private6  = mustIP("fd00::1")
++		private4a        = mustIP("10.0.0.1")
++		private4b        = mustIP("172.16.0.1")
++		private4c        = mustIP("192.168.1.1")
++		private6         = mustIP("fd00::1")
++		private6mapped4a = mustIP("::ffff:10.0.0.1")
++		private6mapped4b = mustIP("::ffff:172.16.0.1")
++		private6mapped4c = mustIP("::ffff:192.168.1.1")
+ 
+ 		unspecified4 = AddrFrom4([4]byte{})
+ 		unspecified6 = IPv6Unspecified()
+@@ -585,6 +588,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:            unicast4,
+ 			globalUnicast: true,
+ 		},
++		{
++			name:          "unicast v6 mapped v4Addr",
++			ip:            AddrFrom16(unicast4.As16()),
++			globalUnicast: true,
++		},
+ 		{
+ 			name:          "unicast v6Addr",
+ 			ip:            unicast6,
+@@ -606,6 +614,12 @@ func TestIPProperties(t *testing.T) {
+ 			linkLocalMulticast: true,
+ 			multicast:          true,
+ 		},
++		{
++			name:               "multicast v6 mapped v4Addr",
++			ip:                 AddrFrom16(multicast4.As16()),
++			linkLocalMulticast: true,
++			multicast:          true,
++		},
+ 		{
+ 			name:               "multicast v6Addr",
+ 			ip:                 multicast6,
+@@ -623,6 +637,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:               llu4,
+ 			linkLocalUnicast: true,
+ 		},
++		{
++			name:             "link-local unicast v6 mapped v4Addr",
++			ip:               AddrFrom16(llu4.As16()),
++			linkLocalUnicast: true,
++		},
+ 		{
+ 			name:             "link-local unicast v6Addr",
+ 			ip:               llu6,
+@@ -648,6 +667,11 @@ func TestIPProperties(t *testing.T) {
+ 			ip:       loopback6,
+ 			loopback: true,
+ 		},
++		{
++			name:     "loopback v6 mapped v4Addr",
++			ip:       AddrFrom16(AddrFrom16([16]byte{15: 0x01}).As16()),
++			loopback: true,
++		},
+ 		{
+ 			name:                    "interface-local multicast v6Addr",
+ 			ip:                      ilm6,
+@@ -684,6 +708,24 @@ func TestIPProperties(t *testing.T) {
+ 			globalUnicast: true,
+ 			private:       true,
+ 		},
++		{
++			name:          "private v6 mapped v4Addr 10/8",
++			ip:            private6mapped4a,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 172.16/12",
++			ip:            private6mapped4b,
++			globalUnicast: true,
++			private:       true,
++		},
++		{
++			name:          "private v6 mapped v4Addr 192.168/16",
++			ip:            private6mapped4c,
++			globalUnicast: true,
++			private:       true,
++		},
+ 		{
+ 			name:        "unspecified v4Addr",
+ 			ip:          unspecified4,
+@@ -1837,6 +1879,7 @@ func TestNoAllocs(t *testing.T) {
+ 	test("IPv6LinkLocalAllNodes", func() { sinkIP = IPv6LinkLocalAllNodes() })
+ 	test("IPv6Unspecified", func() { sinkIP = IPv6Unspecified() })
+ 
++
+ 	// IP methods
+ 	test("IP.IsZero", func() { sinkBool = MustParseAddr("1.2.3.4").IsZero() })
+ 	test("IP.BitLen", func() { sinkBool = MustParseAddr("1.2.3.4").BitLen() == 8 })
+-- 
+2.45.2
+


### PR DESCRIPTION
Backport of fix for CVE 2024-24790 to Go1.19
https://go-review.googlesource.com/c/go/+/590315