### PR TITLE
Rebase to Go1.21.13

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "github.com/golang-fips/go": "main",
   "github.com/golang-fips/openssl-fips": "b175be2ccd46683a51cba60a9a2087b09593317d",
-  "github.com/golang/go": "go1.21.11"
+  "github.com/golang/go": "go1.21.13"
 }


### PR DESCRIPTION
Rebase to Go1.21.13 (technically 1.21.12 contains fix for CVE 2024-24791) but since we have a latest release, rebase to that
