### PR TITLE
Only load openssl if fips equals "1"

### DIFF
--- a/patches/018-fix-std-crypto.patch
+++ b/patches/018-fix-std-crypto.patch
@@ -17,7 +17,7 @@ index 3d3a9a36ee..b7a65a1f6e 100644
 +		fips = "1"
 +	}
 +
-+	if fips == "" {
++	if fips != "1" {
 +		return
 +	}
 +


### PR DESCRIPTION
This commit avoids loading openssl whenever GOLANG_FIPS is not 1. Previously only an unset variable would cause the library load to be skipped, but users may also expect to be able to set eg. GOLANG_FIPS=0 in environments without openssl.