### PR TITLE
Update initial openssl patch

### DIFF
--- a/patches/001-initial-openssl-for-fips.patch
+++ b/patches/001-initial-openssl-for-fips.patch
@@ -2348,24 +2348,24 @@ index 0c2cbf3182..e01c24292e 100644
  	} else {
  		testCurve = elliptic.P384()
 diff --git a/src/go.mod b/src/go.mod
-index 01d759c800..070c9e87ee 100644
+index 01d759c800..f13af41b7a 100644
 --- a/src/go.mod
 +++ b/src/go.mod
 @@ -3,6 +3,7 @@ module std
  go 1.21
  
  require (
-+	github.com/golang-fips/openssl v0.0.0-20240418160119-bad1c00e6bbe
++	github.com/golang-fips/openssl v0.0.0-20240830121749-972af39412e2
  	golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d
  	golang.org/x/net v0.12.1-0.20240412193743-ef58d90fdfc5
  )
 diff --git a/src/go.sum b/src/go.sum
-index f83343a0a1..c6294ac7bf 100644
+index f83343a0a1..2d926818b8 100644
 --- a/src/go.sum
 +++ b/src/go.sum
 @@ -1,3 +1,5 @@
-+github.com/golang-fips/openssl v0.0.0-20240418160119-bad1c00e6bbe h1:JwklyCiwQZrO0NE0s3HnCk0KbPcY/Dg1FCuN53KkX+g=
-+github.com/golang-fips/openssl v0.0.0-20240418160119-bad1c00e6bbe/go.mod h1:LBziBt5PA8FeliZ0KnhnWMrrHzvAsMWZUlYWOYKkpBI=
++github.com/golang-fips/openssl v0.0.0-20240830121749-972af39412e2 h1:YcC2OtDNGCcn2qTnNhGb2Zl4lUwOgTMVAc42hPaf7hk=
++github.com/golang-fips/openssl v0.0.0-20240830121749-972af39412e2/go.mod h1:LBziBt5PA8FeliZ0KnhnWMrrHzvAsMWZUlYWOYKkpBI=
  golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d h1:LiA25/KWKuXfIq5pMIBq1s5hz3HQxhJJSu/SUGlD+SM=
  golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
  golang.org/x/net v0.12.1-0.20240412193743-ef58d90fdfc5 h1:BIx9jz/hjPE1CesqfHzRaf2JsOjDxZrKAVr//XXJh0U=
@@ -4703,10 +4703,10 @@ diff --git a/src/crypto/internal/boring/notboring.go b/src/vendor/github.com/gol
 similarity index 63%
 rename from src/crypto/internal/boring/notboring.go
 rename to src/vendor/github.com/golang-fips/openssl/openssl/notboring.go
-index 1c5e4c742d..5093cdef43 100644
+index 1c5e4c742d..11878e37a0 100644
 --- a/src/crypto/internal/boring/notboring.go
 +++ b/src/vendor/github.com/golang-fips/openssl/openssl/notboring.go
-@@ -2,32 +2,34 @@
+@@ -2,32 +2,35 @@
  // Use of this source code is governed by a BSD-style
  // license that can be found in the LICENSE file.
  
@@ -4723,6 +4723,7 @@ index 1c5e4c742d..5093cdef43 100644
 -	"crypto/internal/boring/sig"
  	"hash"
 +	"io"
++	"math/big"
  )
  
 -const available = false
@@ -4749,7 +4750,7 @@ index 1c5e4c742d..5093cdef43 100644
  type randReader int
  
  func (randReader) Read(b []byte) (int, error) { panic("boringcrypto: not available") }
-@@ -40,16 +42,9 @@ func NewSHA256() hash.Hash { panic("boringcrypto: not available") }
+@@ -40,16 +43,9 @@ func NewSHA256() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA384() hash.Hash { panic("boringcrypto: not available") }
  func NewSHA512() hash.Hash { panic("boringcrypto: not available") }
  
@@ -4766,7 +4767,7 @@ index 1c5e4c742d..5093cdef43 100644
  
  type PublicKeyECDSA struct{ _ int }
  type PrivateKeyECDSA struct{ _ int }
-@@ -63,17 +58,42 @@ func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error)
+@@ -63,17 +59,42 @@ func NewPrivateKeyECDSA(curve string, X, Y, D BigInt) (*PrivateKeyECDSA, error)
  func NewPublicKeyECDSA(curve string, X, Y BigInt) (*PublicKeyECDSA, error) {
  	panic("boringcrypto: not available")
  }
@@ -4811,7 +4812,7 @@ index 1c5e4c742d..5093cdef43 100644
  	panic("boringcrypto: not available")
  }
  func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
-@@ -82,7 +102,7 @@ func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
+@@ -82,7 +103,7 @@ func DecryptRSAPKCS1(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
  func DecryptRSANoPadding(priv *PrivateKeyRSA, ciphertext []byte) ([]byte, error) {
  	panic("boringcrypto: not available")
  }
@@ -4820,7 +4821,7 @@ index 1c5e4c742d..5093cdef43 100644
  	panic("boringcrypto: not available")
  }
  func EncryptRSAPKCS1(pub *PublicKeyRSA, msg []byte) ([]byte, error) {
-@@ -98,25 +118,23 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error
+@@ -98,25 +119,23 @@ func NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv BigInt) (*PrivateKeyRSA, error
  	panic("boringcrypto: not available")
  }
  func NewPublicKeyRSA(N, E BigInt) (*PublicKeyRSA, error) { panic("boringcrypto: not available") }
@@ -6146,10 +6147,10 @@ index 0000000000..2eedd5b8c6
 +#endif
 diff --git a/src/vendor/github.com/golang-fips/openssl/openssl/openssl_port_hmac.c b/src/vendor/github.com/golang-fips/openssl/openssl/openssl_port_hmac.c
 new file mode 100644
-index 0000000000..a5996d66f2
+index 0000000000..d26ce90c82
 --- /dev/null
 +++ b/src/vendor/github.com/golang-fips/openssl/openssl/openssl_port_hmac.c
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,236 @@
 +// This file contains HMAC portability wrappers.
 +// +build linux
 +// +build !android
@@ -6166,7 +6167,12 @@ index 0000000000..a5996d66f2
 +		   (int type, ENGINE *e, const unsigned char *key, int keylen),
 +		   (type, e, key, keylen))
 +DEFINEFUNCINTERNAL(int, EVP_MD_CTX_reset, (EVP_MD_CTX *ctx), (ctx))
++
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 +DEFINEFUNCINTERNAL(const EVP_MD *, EVP_MD_CTX_get0_md, (const EVP_MD_CTX *ctx), (ctx))
++#else
++DEFINEFUNCINTERNAL(const EVP_MD *, EVP_MD_CTX_md, (const EVP_MD_CTX *ctx), (ctx))
++#endif
 +DEFINEFUNCINTERNAL(int, EVP_MD_CTX_copy_ex, (EVP_MD_CTX *out, const EVP_MD_CTX *in), (out, in))
 +
 +/* EVP_DigestSignUpdate is converted from a macro in 3.0 */
@@ -6231,7 +6237,13 @@ index 0000000000..a5996d66f2
 +  int ret;
 +  const EVP_MD *md;
 +
++
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 +  md = _goboringcrypto_internal_EVP_MD_CTX_get0_md(ctx->mdctx);
++#else
++  md = _goboringcrypto_internal_EVP_MD_CTX_md(ctx->mdctx);
++#endif
++
 +  if (!md)
 +    return -1;
 +
@@ -7544,11 +7556,11 @@ index cf82f3f64f..0b55cedc91 100644
  
  type sha512Ctx struct {
 diff --git a/src/vendor/modules.txt b/src/vendor/modules.txt
-index 53ad662c63..8c6b162adf 100644
+index 53ad662c63..8126524580 100644
 --- a/src/vendor/modules.txt
 +++ b/src/vendor/modules.txt
 @@ -1,3 +1,6 @@
-+# github.com/golang-fips/openssl v0.0.0-20240418160119-bad1c00e6bbe
++# github.com/golang-fips/openssl v0.0.0-20240830121749-972af39412e2
 +## explicit; go 1.18
 +github.com/golang-fips/openssl/openssl
  # golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d


### PR DESCRIPTION
The initial openssl patch was not updated in the previous update to the openssl bindings.