### PR TITLE
Allow fetching from a fork of the Go repo

### DIFF
--- a/scripts/setup-go-submodule.sh
+++ b/scripts/setup-go-submodule.sh
@@ -14,7 +14,7 @@ if [ -z "${GIT_REF}" ]; then
     fi
 fi
 
-git submodule add --force https://github.com/golang/go.git
+git submodule add --force ${GOLANG_REPO:-https://github.com/golang/go.git}
 git submodule update
 
 pushd go


### PR DESCRIPTION
Some organizations use a fork of the Go repository rather than the upstream repo; those organizations can set the environment variable `GOLANG_REPO` to point to that repo for the fetch instead.