### PR TITLE
[Backport] fix Config.Time in tests using expired certificates

### DIFF
--- a/patches/012-fix_expired_certificates.patch
+++ b/patches/012-fix_expired_certificates.patch
@@ -1,0 +1,200 @@
+From cf2e74a83536cc11d5ce2ac87935141cb1b4fd6d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Alejandro=20S=C3=A1ez?= <asm@redhat.com>
+Date: Wed, 29 Jan 2025 13:15:56 +0100
+Subject: [PATCH] [Backport] fix Config.Time in tests using expired
+ certificates
+
+Issue link: golang/go#71077
+Upstream patch: https://go-review.googlesource.com/c/go/+/639655
+---
+ src/crypto/tls/handshake_client_test.go | 27 +++++++++++++++----------
+ src/crypto/tls/handshake_server_test.go |  1 +
+ src/crypto/tls/handshake_test.go        |  2 ++
+ src/crypto/tls/tls_test.go              |  4 +---
+ 4 files changed, 20 insertions(+), 14 deletions(-)
+
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index beb20ad14a..7a7c434b85 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -881,6 +881,7 @@ func testResumption(t *testing.T, version uint16) {
+ 		MaxVersion:   version,
+ 		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
+ 		Certificates: testConfig.Certificates,
++		Time:         testTime,
+ 	}
+ 
+ 	issuer, err := x509.ParseCertificate(testRSACertificateIssuer)
+@@ -897,6 +898,7 @@ func testResumption(t *testing.T, version uint16) {
+ 		ClientSessionCache: NewLRUClientSessionCache(32),
+ 		RootCAs:            rootCAs,
+ 		ServerName:         "example.golang",
++		Time:               testTime,
+ 	}
+ 
+ 	testResumeState := func(test string, didResume bool) {
+@@ -944,20 +946,20 @@ func testResumption(t *testing.T, version uint16) {
+ 	}
+ 
+ 	// An old session ticket can resume, but the server will provide a ticket encrypted with a fresh key.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
+ 	testResumeState("ResumeWithOldTicket", true)
+ 	if bytes.Equal(ticket[:ticketKeyNameLen], getTicket()[:ticketKeyNameLen]) {
+ 		t.Fatal("old first ticket matches the fresh one")
+ 	}
+ 
+ 	// Now the session tickey key is expired, so a full handshake should occur.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + time.Minute) }
+ 	testResumeState("ResumeWithExpiredTicket", false)
+ 	if bytes.Equal(ticket, getTicket()) {
+ 		t.Fatal("expired first ticket matches the fresh one")
+ 	}
+ 
+-	serverConfig.Time = func() time.Time { return time.Now() } // reset the time back
++	serverConfig.Time = testTime // reset the time back
+ 	key1 := randomKey()
+ 	serverConfig.SetSessionTicketKeys([][32]byte{key1})
+ 
+@@ -974,11 +976,11 @@ func testResumption(t *testing.T, version uint16) {
+ 	testResumeState("KeyChangeFinish", true)
+ 
+ 	// Age the session ticket a bit, but not yet expired.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*time.Hour + time.Minute) }
+ 	testResumeState("OldSessionTicket", true)
+ 	ticket = getTicket()
+ 	// Expire the session ticket, which would force a full handshake.
+-	serverConfig.Time = func() time.Time { return time.Now().Add(24*8*time.Hour + time.Minute) }
++	serverConfig.Time = func() time.Time { return testTime().Add(24*8*time.Hour + time.Minute) }
+ 	testResumeState("ExpiredSessionTicket", false)
+ 	if bytes.Equal(ticket, getTicket()) {
+ 		t.Fatal("new ticket wasn't provided after old ticket expired")
+@@ -988,15 +990,14 @@ func testResumption(t *testing.T, version uint16) {
+ 	d := 0 * time.Hour
+ 	for i := 0; i < 13; i++ {
+ 		d += 12 * time.Hour
+-		serverConfig.Time = func() time.Time { return time.Now().Add(d) }
++		serverConfig.Time = func() time.Time { return testTime().Add(d) }
+ 		testResumeState("OldSessionTicket", true)
+ 	}
+ 	// Expire it (now a little more than 7 days) and make sure a full
+ 	// handshake occurs for TLS 1.2. Resumption should still occur for
+ 	// TLS 1.3 since the client should be using a fresh ticket sent over
+ 	// by the server.
+-	d += 12 * time.Hour
+-	serverConfig.Time = func() time.Time { return time.Now().Add(d) }
++	d += 12*time.Hour + time.Minute
+ 	if version == VersionTLS13 {
+ 		testResumeState("ExpiredSessionTicket", true)
+ 	} else {
+@@ -1012,6 +1013,7 @@ func testResumption(t *testing.T, version uint16) {
+ 		MaxVersion:   version,
+ 		CipherSuites: []uint16{TLS_RSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_RC4_128_SHA},
+ 		Certificates: testConfig.Certificates,
++		Time:         testTime,
+ 	}
+ 	serverConfig.SetSessionTicketKeys([][32]byte{key2})
+ 
+@@ -1721,6 +1723,7 @@ func testVerifyConnection(t *testing.T, version uint16) {
+ 			Certificates: []Certificate{testConfig.Certificates[0]},
+ 			ClientCAs:    rootCAs,
+ 			NextProtos:   []string{"protocol1"},
++			Time:         testTime,
+ 		}
+ 		serverConfig.Certificates[0].SignedCertificateTimestamps = [][]byte{[]byte("dummy sct 1"), []byte("dummy sct 2")}
+ 		serverConfig.Certificates[0].OCSPStaple = []byte("dummy ocsp")
+@@ -1733,6 +1736,7 @@ func testVerifyConnection(t *testing.T, version uint16) {
+ 			ServerName:         "example.golang",
+ 			Certificates:       []Certificate{testConfig.Certificates[0]},
+ 			NextProtos:         []string{"protocol1"},
++			Time:               testTime,
+ 		}
+ 		test.configureClient(clientConfig, &clientCalled)
+ 
+@@ -2021,7 +2025,7 @@ func testVerifyPeerCertificate(t *testing.T, version uint16) {
+ 			config.ServerName = "example.golang"
+ 			config.ClientAuth = RequireAndVerifyClientCert
+ 			config.ClientCAs = rootCAs
+-			config.Time = now
++			config.Time = testTime
+ 			config.MaxVersion = version
+ 			config.Certificates = make([]Certificate, 1)
+ 			config.Certificates[0].Certificate = [][]byte{testRSACertificate}
+@@ -2156,7 +2160,7 @@ func testBuffering(t *testing.T, version uint16) {
+ }
+ 
+ func TestAlertFlushing(t *testing.T) {
+-       t.Skip("unsupported in FIPS mode, different error returned")
++	t.Skip("unsupported in FIPS mode, different error returned")
+ 	c, s := localPipe(t)
+ 	done := make(chan bool)
+ 
+@@ -2352,7 +2356,7 @@ func testGetClientCertificate(t *testing.T, version uint16) {
+ 		serverConfig.RootCAs = x509.NewCertPool()
+ 		serverConfig.RootCAs.AddCert(issuer)
+ 		serverConfig.ClientCAs = serverConfig.RootCAs
+-		serverConfig.Time = func() time.Time { return time.Unix(1476984729, 0) }
++		serverConfig.Time = testTime,
+ 		serverConfig.MaxVersion = version
+ 
+ 		clientConfig := testConfig.Clone()
+@@ -2523,6 +2527,7 @@ func testResumptionKeepsOCSPAndSCT(t *testing.T, ver uint16) {
+ 		ClientSessionCache: NewLRUClientSessionCache(32),
+ 		ServerName:         "example.golang",
+ 		RootCAs:            roots,
++		Time: testTime,
+ 	}
+ 	serverConfig := testConfig.Clone()
+ 	serverConfig.MaxVersion = ver
+diff --git a/src/crypto/tls/handshake_server_test.go b/src/crypto/tls/handshake_server_test.go
+index b2e81077be..de49e7b97b 100644
+--- a/src/crypto/tls/handshake_server_test.go
++++ b/src/crypto/tls/handshake_server_test.go
+@@ -488,6 +488,7 @@ func testCrossVersionResume(t *testing.T, version uint16) {
+ 		ClientSessionCache: NewLRUClientSessionCache(1),
+ 		ServerName:         "servername",
+ 		MinVersion:         VersionTLS10,
++		Time:               testTime,
+ 	}
+ 
+ 	// Establish a session at TLS 1.1.
+diff --git a/src/crypto/tls/handshake_test.go b/src/crypto/tls/handshake_test.go
+index bacc8b7d4f..0848a2de67 100644
+--- a/src/crypto/tls/handshake_test.go
++++ b/src/crypto/tls/handshake_test.go
+@@ -429,6 +429,8 @@ func fromHex(s string) []byte {
+ 	return b
+ }
+ 
++var testTime = func() time.Time { return time.Unix(1476984729, 0) }
++
+ var testRSACertificate = fromHex("3082024b308201b4a003020102020900e8f09d3fe25beaa6300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301a310b3009060355040a1302476f310b300906035504031302476f30819f300d06092a864886f70d010101050003818d0030818902818100db467d932e12270648bc062821ab7ec4b6a25dfe1e5245887a3647a5080d92425bc281c0be97799840fb4f6d14fd2b138bc2a52e67d8d4099ed62238b74a0b74732bc234f1d193e596d9747bf3589f6c613cc0b041d4d92b2b2423775b1c3bbd755dce2054cfa163871d1e24c4f31d1a508baab61443ed97a77562f414c852d70203010001a38193308190300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff0402300030190603551d0e041204109f91161f43433e49a6de6db680d79f60301b0603551d230414301280104813494d137e1631bba301d5acab6e7b30190603551d1104123010820e6578616d706c652e676f6c616e67300d06092a864886f70d01010b0500038181009d30cc402b5b50a061cbbae55358e1ed8328a9581aa938a495a1ac315a1a84663d43d32dd90bf297dfd320643892243a00bccf9c7db74020015faad3166109a276fd13c3cce10c5ceeb18782f16c04ed73bbb343778d0c1cf10fa1d8408361c94c722b9daedb4606064df4c1b33ec0d1bd42d4dbfe3d1360845c21d33be9fae7")
+ 
+ var testRSACertificateIssuer = fromHex("3082021930820182a003020102020900ca5e4e811a965964300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f7430819f300d06092a864886f70d010101050003818d0030818902818100d667b378bb22f34143b6cd2008236abefaf2852adf3ab05e01329e2c14834f5105df3f3073f99dab5442d45ee5f8f57b0111c8cb682fbb719a86944eebfffef3406206d898b8c1b1887797c9c5006547bb8f00e694b7a063f10839f269f2c34fff7a1f4b21fbcd6bfdfb13ac792d1d11f277b5c5b48600992203059f2a8f8cc50203010001a35d305b300e0603551d0f0101ff040403020204301d0603551d250416301406082b0601050507030106082b06010505070302300f0603551d130101ff040530030101ff30190603551d0e041204104813494d137e1631bba301d5acab6e7b300d06092a864886f70d01010b050003818100c1154b4bab5266221f293766ae4138899bd4c5e36b13cee670ceeaa4cbdf4f6679017e2fe649765af545749fe4249418a56bd38a04b81e261f5ce86b8d5c65413156a50d12449554748c59a30c515bc36a59d38bddf51173e899820b282e40aa78c806526fd184fb6b4cf186ec728edffa585440d2b3225325f7ab580e87dd76")
+diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
+index d8a43add17..5fa6e90069 100644
+--- a/src/crypto/tls/tls_test.go
++++ b/src/crypto/tls/tls_test.go
+@@ -1058,8 +1058,6 @@ func TestConnectionState(t *testing.T) {
+ 	rootCAs := x509.NewCertPool()
+ 	rootCAs.AddCert(issuer)
+ 
+-	now := func() time.Time { return time.Unix(1476984729, 0) }
+-
+ 	const alpnProtocol = "golang"
+ 	const serverName = "example.golang"
+ 	var scts = [][]byte{[]byte("dummy sct 1"), []byte("dummy sct 2")}
+@@ -1075,7 +1073,7 @@ func TestConnectionState(t *testing.T) {
+ 		}
+ 		t.Run(name, func(t *testing.T) {
+ 			config := &Config{
+-				Time:         now,
++				Time:         testTime,
+ 				Rand:         zeroSource{},
+ 				Certificates: make([]Certificate, 1),
+ 				MaxVersion:   v,
+-- 
+2.47.1
+


### PR DESCRIPTION
Issue link: golang/go#71077
Upstream patch: https://go-review.googlesource.com/c/go/+/639655