### PR TITLE
backport of fix for variable time code in crypto/internal/nistec/p256NegCond on ppc64le Go1.19

### DIFF
--- a/patches/013-fix-var-time-p256NegCond-etc.patch
+++ b/patches/013-fix-var-time-p256NegCond-etc.patch
@@ -1,0 +1,86 @@
+From 69f16f259fa2c34202d6ef7171075ddbdf3f18f5 Mon Sep 17 00:00:00 2001
+From: Archana Ravindar <aravinda@redhat.com>
+Date: Tue, 18 Feb 2025 18:14:56 +0530
+Subject: [PATCH 1/1] backport fix variable time p256NegCond and remove extra
+ comma
+
+---
+ src/crypto/internal/nistec/p256_asm_ppc64le.s | 22 +++++++++++++++----
+ src/crypto/tls/handshake_client_test.go       |  2 +-
+ 2 files changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/src/crypto/internal/nistec/p256_asm_ppc64le.s b/src/crypto/internal/nistec/p256_asm_ppc64le.s
+index 0593ef370f..ba1b6cd715 100644
+--- a/src/crypto/internal/nistec/p256_asm_ppc64le.s
++++ b/src/crypto/internal/nistec/p256_asm_ppc64le.s
+@@ -124,14 +124,23 @@ GLOBL p256mul<>(SB), 8, $160
+ #define PH    V31
+ 
+ #define CAR1  V6
++#define SEL V8
++#define ZER V9
++
++
+ // func p256NegCond(val *p256Point, cond int)
+ TEXT ·p256NegCond(SB), NOSPLIT, $0-16
+ 	MOVD val+0(FP), P1ptr
+ 	MOVD $16, R16
+ 
+-	MOVD cond+8(FP), R6
+-	CMP  $0, R6
+-	BC   12, 2, LR      // just return if cond == 0
++	// Copy cond into SEL (cond is R1 + 8 (cond offset) + 32)
++	MOVD $40, R17
++	LXVDSX (R1)(R17), SEL
++	// Zeroize ZER
++	VSPLTISB $0, ZER
++	// SEL controls whether to return the original value (Y1H/Y1L)
++	// or the negated value (T1H/T1L).
++	VCMPEQUD SEL, ZER, SEL
+ 
+ 	MOVD $p256mul<>+0x00(SB), CPOOL
+ 
+@@ -148,6 +157,9 @@ TEXT ·p256NegCond(SB), NOSPLIT, $0-16
+ 	VSUBUQM  PL, Y1L, T1L       // subtract part2 giving result
+ 	VSUBEUQM PH, Y1H, CAR1, T1H // subtract part1 using carry from part2
+ 
++	VSEL T1H, Y1H, SEL, T1H
++	VSEL T1L, Y1L, SEL, T1L
++
+ 	XXPERMDI T1H, T1H, $2, T1H
+ 	XXPERMDI T1L, T1L, $2, T1L
+ 
+@@ -164,6 +176,8 @@ TEXT ·p256NegCond(SB), NOSPLIT, $0-16
+ #undef PL
+ #undef PH
+ #undef CAR1
++#undef SEL
++#undef ZER
+ 
+ #define P3ptr   R3
+ #define P1ptr   R4
+@@ -1208,7 +1222,7 @@ sqrLoop:
+ 	BR	sqrLoop
+ 
+ done:
+-        MOVD $p256mul<>+0x00(SB), CPOOL
++	MOVD $p256mul<>+0x00(SB), CPOOL
+ 
+ 	XXPERMDI T0, T0, $2, T0
+ 	XXPERMDI T1, T1, $2, T1
+diff --git a/src/crypto/tls/handshake_client_test.go b/src/crypto/tls/handshake_client_test.go
+index 7a7c434b85..a9e7d68d2a 100644
+--- a/src/crypto/tls/handshake_client_test.go
++++ b/src/crypto/tls/handshake_client_test.go
+@@ -2356,7 +2356,7 @@ func testGetClientCertificate(t *testing.T, version uint16) {
+ 		serverConfig.RootCAs = x509.NewCertPool()
+ 		serverConfig.RootCAs.AddCert(issuer)
+ 		serverConfig.ClientCAs = serverConfig.RootCAs
+-		serverConfig.Time = testTime,
++		serverConfig.Time = testTime
+ 		serverConfig.MaxVersion = version
+ 
+ 		clientConfig := testConfig.Clone()
+-- 
+2.47.1
+


### PR DESCRIPTION
Backport of fix https://go-review.googlesource.com/c/go/+/643735 to Go1.19

Fixes CVE-2025-22866
also remove an extra comma in handshake_client_test.go which causes all.bash to fail 