### PR TITLE
[go1.21] Remove the call to parallelize TestEverything

### DIFF
--- a/patches/011-remove-parallel-test-everything.patch
+++ b/patches/011-remove-parallel-test-everything.patch
@@ -1,0 +1,12 @@
+diff --git a/src/crypto/rsa/rsa_test.go b/src/crypto/rsa/rsa_test.go
+index 0a6b636800..4b12ba37fc 100644
+--- a/src/crypto/rsa/rsa_test.go
++++ b/src/crypto/rsa/rsa_test.go
+@@ -227,7 +227,6 @@ func TestEverything(t *testing.T) {
+ 	for size := min; size <= max; size++ {
+ 		size := size
+ 		t.Run(fmt.Sprintf("%d", size), func(t *testing.T) {
+-			t.Parallel()
+ 			priv, err := GenerateKeyNotBoring(rand.Reader, size)
+ 			if err != nil {
+ 				t.Errorf("GenerateKey(%d): %v", size, err)


### PR DESCRIPTION
This method, while good for performance, is interfering with OpenSSL and Go interactions by accidentally hiding errors. This is due to likely to the goroutine being preempted during CGO calls. There is a series of circumstances that leads to the OpenSSL thread local error state being overwritten causing us to lose the error, and thus fail the test.