### PR TITLE
net/http: reject newlines in chunk-size lines (backport to 1.17)

### DIFF
--- a/src/net/http/internal/chunked.go
+++ b/src/net/http/internal/chunked.go
@@ -159,6 +159,19 @@ func readChunkLine(b *bufio.Reader) ([]byte, error) {
 		}
 		return nil, err
 	}
+
+	// RFC 9112 permits parsers to accept a bare \n as a line ending in headers,
+	// but not in chunked encoding lines. See https://www.rfc-editor.org/errata/eid7633,
+	// which explicitly rejects a clarification permitting \n as a chunk terminator.
+	//
+	// Verify that the line ends in a CRLF, and that no CRs appear before the end.
+	if idx := bytes.IndexByte(p, '\r'); idx == -1 {
+		return nil, errors.New("chunked line ends with bare LF")
+	} else if idx != len(p)-2 {
+		return nil, errors.New("invalid CR in chunked line")
+	}
+	p = p[:len(p)-2] // trim CRLF
+
 	if len(p) >= maxLineLength {
 		return nil, ErrLineTooLong
 	}
@@ -166,14 +179,14 @@ func readChunkLine(b *bufio.Reader) ([]byte, error) {
 }
 
 func trimTrailingWhitespace(b []byte) []byte {
-	for len(b) > 0 && isASCIISpace(b[len(b)-1]) {
+	for len(b) > 0 && isOWS(b[len(b)-1]) {
 		b = b[:len(b)-1]
 	}
 	return b
 }
 
-func isASCIISpace(b byte) bool {
-	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+func isOWS(b byte) bool {
+	return b == ' ' || b == '\t'
 }
 
 // removeChunkExtension removes any chunk-extension from p.

--- a/src/net/http/internal/chunked_test.go
+++ b/src/net/http/internal/chunked_test.go
@@ -252,6 +252,33 @@ func TestChunkReaderByteAtATime(t *testing.T) {
 	}
 }
 
+func TestChunkInvalidInputs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		b    string
+	}{{
+		name: "bare LF in chunk size",
+		b:    "1\na\r\n0\r\n",
+	}, {
+		name: "extra LF in chunk size",
+		b:    "1\r\r\na\r\n0\r\n",
+	}, {
+		name: "bare LF in chunk data",
+		b:    "1\r\na\n0\r\n",
+	}, {
+		name: "bare LF in chunk extension",
+		b:    "1;\na\r\n0\r\n",
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			r := NewChunkedReader(strings.NewReader(test.b))
+			got, err := io.ReadAll(r)
+			if err == nil {
+				t.Fatalf("unexpectedly parsed invalid chunked data:\n%q", got)
+			}
+		})
+	}
+}
+
 type funcReader struct {
 	f   func(iteration int) ([]byte, error)
 	i   int

--- a/src/net/http/serve_test.go
+++ b/src/net/http/serve_test.go
@@ -6610,3 +6610,52 @@ func testQuerySemicolon(t *testing.T, query string, wantX string, allowSemicolon
 		}
 	}
 }
+
+func TestInvalidChunkedBodies(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		b    string
+	}{{
+		name: "bare LF in chunk size",
+		b:    "1\na\r\n0\r\n\r\n",
+	}, {
+		name: "bare LF at body end",
+		b:    "1\r\na\r\n0\r\n\n",
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			reqc := make(chan error)
+			ts := newClientServerTest(t, false, HandlerFunc(func(w ResponseWriter, r *Request) {
+				got, err := io.ReadAll(r.Body)
+				if err == nil {
+					t.Logf("read body: %q", got)
+				}
+				reqc <- err
+			})).ts
+
+			serverURL, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			conn, err := net.Dial("tcp", serverURL.Host)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := conn.Write([]byte(
+				"POST / HTTP/1.1\r\n" +
+					"Host: localhost\r\n" +
+					"Transfer-Encoding: chunked\r\n" +
+					"Connection: close\r\n" +
+					"\r\n" +
+					test.b)); err != nil {
+				t.Fatal(err)
+			}
+			conn.(*net.TCPConn).CloseWrite()
+
+			if err := <-reqc; err == nil {
+				t.Errorf("server handler: io.ReadAll(r.Body) succeeded, want error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://go-review.googlesource.com/c/go/+/657216

Fixes: CVE-2025-22871