### PR TITLE
Implement HKDF for TLS

### DIFF
--- a/patches/fips.patch
+++ b/patches/fips.patch
@@ -1,6 +1,6 @@
-commit 2134a7a6e0854a3bc997b5f1514ff926f597d247
+commit 2b96c8b5994c6eebb04fa0d62fd0ecf812b9db36
 Author: Derek Parker <parkerderek86@gmail.com>
-Date:   Wed Apr 30 11:51:39 2025 -0700
+Date:   Thu May 22 09:10:23 2025 -0700
 
     fips.patch
 
@@ -4634,10 +4634,10 @@ index 76fff6974e..c121172b79 100644
  
  	// For an overview of the TLS 1.3 handshake, see RFC 8446, Section 2.
 diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
-index 38d6d3f7be..d0338ca246 100644
+index 38d6d3f7be..82185c8a3c 100644
 --- a/src/crypto/tls/key_schedule.go
 +++ b/src/crypto/tls/key_schedule.go
-@@ -7,6 +7,7 @@ package tls
+@@ -7,10 +7,12 @@ package tls
  import (
  	"crypto/ecdh"
  	"crypto/hmac"
@@ -4645,7 +4645,12 @@ index 38d6d3f7be..d0338ca246 100644
  	"crypto/internal/fips140/mlkem"
  	"crypto/internal/fips140/tls13"
  	"errors"
-@@ -20,13 +21,13 @@ import (
+ 	"hash"
++	"internal/byteorder"
+ 	"io"
+ )
+ 
+@@ -20,13 +22,13 @@ import (
  // nextTrafficSecret generates the next traffic secret, given the current one,
  // according to RFC 8446, Section 7.2.
  func (c *cipherSuiteTLS13) nextTrafficSecret(trafficSecret []byte) []byte {
@@ -4662,7 +4667,7 @@ index 38d6d3f7be..d0338ca246 100644
  	return
  }
  
-@@ -34,7 +35,7 @@ func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
+@@ -34,7 +36,7 @@ func (c *cipherSuiteTLS13) trafficKey(trafficSecret []byte) (key, iv []byte) {
  // to RFC 8446, Section 4.4.4. See sections 4.4 and 4.2.11.2 for the baseKey
  // selection.
  func (c *cipherSuiteTLS13) finishedHash(baseKey []byte, transcript hash.Hash) []byte {
@@ -4671,7 +4676,7 @@ index 38d6d3f7be..d0338ca246 100644
  	verifyData := hmac.New(c.hash.New, finishedKey)
  	verifyData.Write(transcript.Sum(nil))
  	return verifyData.Sum(nil)
-@@ -97,3 +98,11 @@ func curveIDForCurve(curve ecdh.Curve) (CurveID, bool) {
+@@ -97,3 +99,23 @@ func curveIDForCurve(curve ecdh.Curve) (CurveID, bool) {
  		return 0, false
  	}
  }
@@ -4679,7 +4684,19 @@ index 38d6d3f7be..d0338ca246 100644
 +// expandLabel returns the value of tls13.ExpandLabel with the given arguments.
 +func expandLabel(newFunc func() hash.Hash, secret []byte, label string, context []byte, length int) []byte {
 +	if boring.Enabled() {
-+		panic("implement me")
++		hkdfLabel := make([]byte, 0, 2+1+len("tls13 ")+len(label)+1+len(context))
++		hkdfLabel = byteorder.BEAppendUint16(hkdfLabel, uint16(length))
++		hkdfLabel = append(hkdfLabel, byte(len("tls13 ")+len(label)))
++		hkdfLabel = append(hkdfLabel, "tls13 "...)
++		hkdfLabel = append(hkdfLabel, label...)
++		hkdfLabel = append(hkdfLabel, byte(len(context)))
++		hkdfLabel = append(hkdfLabel, context...)
++		r, err := boring.ExpandHKDF(newFunc, secret, hkdfLabel)
++		if err != nil {
++			panic(err)
++		}
++		b, _ := io.ReadAll(r)
++		return b[:length]
 +	}
 +	return tls13.ExpandLabel(newFunc, secret, label, context, length)
 +}

--- a/scripts/crypto-test.sh
+++ b/scripts/crypto-test.sh
@@ -96,4 +96,9 @@ run_full_test_suite default ""
 export GOEXPERIMENT=strictfipsruntime
 run_full_test_suite strictfips "-tags=strictfipsruntime"
 
+# Run TLS Handshake tests to test ExpandHKDF
+notify_running "TLS Handshake", "(default)"
+GOLANG_FIPS=1 OPENSSL_FORCE_FIPS_MODE=1 \
+  $GO test -count=1 crypto/tls -run "TestTrafficKey" $VERBOSE
+
 echo ALL TESTS PASSED


### PR DESCRIPTION
This was previously left unimplemented and would panic if invoked. We didn't catch this because we only run a subset of the TLS tests in FIPS mode. This patch adds the test case which would have caught this into our test script and fixes the panic with an implementation of HKDF label expanding.

Fixes #297