### PR TITLE
Go 1.23: Add ubi10, c10s targets to gating

### DIFF
--- a/.github/workflows/gating.yml
+++ b/.github/workflows/gating.yml
@@ -30,4 +30,4 @@ jobs:
     uses: golang-fips/release/.github/workflows/test-ubi-centos.yml@main
     with:
       go_fips_ref: ${{ github.event.pull_request.head.sha }}
-      composes: "ubi8,ubi9,c8s,c9s"
+      composes: "ubi8,ubi9,ubi10,c9s,c10s"


### PR DESCRIPTION
Also remove c8s, which we don't support anymore.

Depends on https://github.com/golang-fips/release/pull/17/files