### PR TITLE
go1.26.3

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "github.com/golang-fips/go": "main",
   "github.com/golang-fips/openssl": "61a53ab338d5f1657c6fe5d856d24528bfdd731d",
-  "github.com/golang/go": "go1.26.2"
+  "github.com/golang/go": "go1.26.3"
 }

--- a/patches/000-fips.patch
+++ b/patches/000-fips.patch
@@ -4868,13 +4868,15 @@ diff --git a/src/crypto/tls/fips140_test.go b/src/crypto/tls/fips140_test.go
 index 96273c0fe0..7096b0eb83 100644
 --- a/src/crypto/tls/fips140_test.go
 +++ b/src/crypto/tls/fips140_test.go
-@@ -7,8 +7,8 @@ package tls
+@@ -7,10 +7,10 @@ package tls
  import (
  	"crypto/ecdsa"
  	"crypto/elliptic"
+ 	"crypto/fips140"
 -	"crypto/internal/boring"
- 	"crypto/rand"
 +	boring "crypto/internal/backend"
+ 	ifips140 "crypto/internal/fips140"
+ 	"crypto/rand"
  	"crypto/rsa"
  	"crypto/x509"
  	"crypto/x509/pkix"
@@ -4975,9 +4977,10 @@ diff --git a/src/crypto/tls/key_schedule.go b/src/crypto/tls/key_schedule.go
 index bfa22449c8..f16c1ea973 100644
 --- a/src/crypto/tls/key_schedule.go
 +++ b/src/crypto/tls/key_schedule.go
-@@ -8,10 +8,12 @@ import (
+@@ -8,11 +8,13 @@ import (
  	"crypto"
  	"crypto/ecdh"
+ 	"crypto/fips140"
  	"crypto/hmac"
 +	boring "crypto/internal/backend"
  	"crypto/internal/fips140/tls13"
@@ -5042,10 +5045,11 @@ diff --git a/src/crypto/tls/tls_test.go b/src/crypto/tls/tls_test.go
 index 39ebb9d2f1..0b213cb61f 100644
 --- a/src/crypto/tls/tls_test.go
 +++ b/src/crypto/tls/tls_test.go
-@@ -11,7 +11,7 @@ import (
+@@ -11,8 +11,8 @@ import (
  	"crypto/ecdh"
  	"crypto/ecdsa"
  	"crypto/elliptic"
+ 	"crypto/fips140"
 -	"crypto/internal/boring"
 +	boring "crypto/internal/backend"
  	"crypto/rand"

--- a/patches/000-fips.patch
+++ b/patches/000-fips.patch
@@ -5301,7 +5301,7 @@ index b6b841b44d..2a1ab9ae06 100644
 +github.com/golang-fips/openssl/v2 v2.0.4-0.20240925082504-4fb8ffc9b3b8/go.mod h1:OYUBsoxLpFu8OFyhZHxfpN8lgcsw8JhTC3BQK7+XUc0=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00 h1:JgcPM1rzpSOZS8y69FQvnY0xN0ciHlpQqwTXJcuZIA4=
  golang.org/x/crypto v0.46.1-0.20251210140736-7dacc380ba00/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
- golang.org/x/net v0.47.1-0.20251128220604-7c360367ab7e h1:PAAT9cIDvIAIRQVz2txQvUFRt3jOlhiO84ihd8XMGlg=
+ golang.org/x/net v0.47.1-0.20260417193450-705de46f8788 h1:fVWwoa/P68Bsajqy2FO4dha7TRBfgf09o932L4USeXI=
 diff --git a/src/go/build/deps_test.go b/src/go/build/deps_test.go
 index f4b7e9dae5..55f52e124a 100644
 --- a/src/go/build/deps_test.go


### PR DESCRIPTION
Bump Go version to go1.26.3 to address CVEs announced in https://groups.google.com/g/golang-announce/c/qcCIEXso47M