### PR TITLE
Update to Go 1.25.12

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "github.com/golang-fips/go": "main",
   "github.com/golang-fips/openssl": "61a53ab338d5f1657c6fe5d856d24528bfdd731d",
-  "github.com/golang/go": "go1.25.11"
+  "github.com/golang/go": "go1.25.12"
 }

--- a/patches/005-idna-reject-ascii-xn.patch
+++ b/patches/005-idna-reject-ascii-xn.patch
@@ -1,0 +1,45 @@
+[go1.25.12] Backport of fix for CVE-2026-39821
+
+https://go-review.googlesource.com/c/net/+/798020
+
+---
+diff --git a/src/vendor/golang.org/x/net/idna/idna10.0.0.go b/src/vendor/golang.org/x/net/idna/idna10.0.0.go
+index 7b37178847..0743e9169f 100644
+--- a/src/vendor/golang.org/x/net/idna/idna10.0.0.go
++++ b/src/vendor/golang.org/x/net/idna/idna10.0.0.go
+@@ -362,7 +362,8 @@ func (p *Profile) process(s string, toASCII bool) (string, error) {
+ 			continue
+ 		}
+ 		if strings.HasPrefix(label, acePrefix) {
+-			u, err2 := decode(label[len(acePrefix):])
++			enc := label[len(acePrefix):]
++			u, err2 := decode(enc)
+ 			if err2 != nil {
+ 				if err == nil {
+ 					err = err2
+@@ -370,6 +371,9 @@ func (p *Profile) process(s string, toASCII bool) (string, error) {
+ 				// Spec says keep the old label.
+ 				continue
+ 			}
++			if err == nil && len(u) > 0 && isASCII(u) {
++				err = punyError(enc)
++			}
+ 			isBidi = isBidi || bidirule.DirectionString(u) != bidi.LeftToRight
+ 			labels.set(u)
+ 			if err == nil && p.fromPuny != nil {
+@@ -424,6 +428,15 @@ func (p *Profile) process(s string, toASCII bool) (string, error) {
+ 	return s, err
+ }
+ 
++func isASCII(s string) bool {
++	for _, c := range []byte(s) {
++		if c >= 0x80 {
++			return false
++		}
++	}
++	return true
++}
++
+ func normalize(p *Profile, s string) (mapped string, isBidi bool, err error) {
+ 	// TODO: consider first doing a quick check to see if any of these checks
+ 	// need to be done. This will make it slower in the general case, but


### PR DESCRIPTION
Also, backport fix for CVE-2026-39821.