### PR TITLE
patches: resolve fips140=auto to 'only' instead of 'on' on FIPS hosts

### DIFF
--- a/patches/001-host-fips-auto.patch
+++ b/patches/001-host-fips-auto.patch
@@ -99,10 +99,10 @@ index de50d61208..22bda7ad4b 100644
 -	return godebug.New(name).Value()
 +	v := godebug.New(name).Value()
 +	// When fips140=auto is set, check host FIPS mode and resolve to
-+	// "on" if enabled, or "" (off) if not.
++	// "only" if enabled, or "" (off) if not.
 +	if name == "#fips140" && v == "auto" {
 +		if hostfips.Enabled() {
-+			return "on"
++			return "only"
 +		}
 +		return ""
 +	}


### PR DESCRIPTION
When a binary built with this toolchain detects a FIPS-enabled host at runtime (via /proc/sys/crypto/fips_enabled), resolve fips140=auto to fips140=only rather than fips140=on. This enforces strict mode, no fallback to non-FIPS algorithms, which is more similar to how we handled any potential fallback case with the openssl based backend.