### PR TITLE
Support strictfipsruntime with no_openssl

### DIFF
--- a/patches/009-strictfips-no-openssl.patch
+++ b/patches/009-strictfips-no-openssl.patch
@@ -1,0 +1,83 @@
+diff --git a/src/crypto/internal/backend/hostfips.go b/src/crypto/internal/backend/hostfips.go
+index 297a16ad5a..5cbc2a421a 100644
+--- a/src/crypto/internal/backend/hostfips.go
++++ b/src/crypto/internal/backend/hostfips.go
+@@ -14,3 +14,7 @@ import (
+ func HostFIPSModeEnabled() bool {
+ 	return hostfips.HostEnabled()
+ }
++
++func HostFIPSModeEnabledNative() bool {
++	return hostfips.Enabled()
++}
+diff --git a/src/crypto/internal/backend/nobackend.go b/src/crypto/internal/backend/nobackend.go
+index 95c2cdc10e..bdba2d552a 100644
+--- a/src/crypto/internal/backend/nobackend.go
++++ b/src/crypto/internal/backend/nobackend.go
+@@ -17,7 +17,7 @@ import (
+ )
+ 
+ func init() {
+-	strictFIPSNonCompliantBinaryCheck()
++	strictFIPSNoOpenSSLRuntimeCheck()
+ }
+ 
+ var enabled = false
+diff --git a/src/crypto/internal/backend/not_strict_fips.go b/src/crypto/internal/backend/not_strict_fips.go
+index e27a631383..0e98c635b3 100644
+--- a/src/crypto/internal/backend/not_strict_fips.go
++++ b/src/crypto/internal/backend/not_strict_fips.go
+@@ -12,5 +12,6 @@ var isStrictFIPS bool = false
+ func strictFIPSOpenSSLRuntimeCheck() {
+ }
+ 
+-func strictFIPSNonCompliantBinaryCheck() {
++func strictFIPSNoOpenSSLRuntimeCheck() {
+ }
++
+diff --git a/src/crypto/internal/backend/strict_fips.go b/src/crypto/internal/backend/strict_fips.go
+index dd2888c78c..09b4c2e65a 100644
+--- a/src/crypto/internal/backend/strict_fips.go
++++ b/src/crypto/internal/backend/strict_fips.go
+@@ -10,6 +10,7 @@ package backend
+ import (
+ 	"fmt"
+ 	"os"
++	"crypto/internal/fips140"
+ )
+ 
+ var isStrictFIPS bool = true
+@@ -21,9 +22,10 @@ func strictFIPSOpenSSLRuntimeCheck() {
+ 	}
+ }
+ 
+-func strictFIPSNonCompliantBinaryCheck() {
+-	if HostFIPSModeEnabled() {
+-		fmt.Fprintln(os.Stderr, "FIPS mode is enabled, but this binary is not compiled with FIPS compliant mode enabled")
++func strictFIPSNoOpenSSLRuntimeCheck() {
++	if HostFIPSModeEnabledNative() && !fips140.Enabled {
++		fmt.Fprintln(os.Stderr, "Host FIPS mode is enabled, but the required GODEBUG=fips140 module is disabled")
+ 		os.Exit(1)
+ 	}
+ }
++
+diff --git a/src/internal/testenv/exec.go b/src/internal/testenv/exec.go
+index 7b251b6022..02a5d01dc2 100644
+--- a/src/internal/testenv/exec.go
++++ b/src/internal/testenv/exec.go
+@@ -130,7 +130,14 @@ func CleanCmdEnv(cmd *exec.Cmd) *exec.Cmd {
+ 	for _, env := range cmd.Environ() {
+ 		// Exclude GODEBUG from the environment to prevent its output
+ 		// from breaking tests that are trying to parse other command output.
+-		if strings.HasPrefix(env, "GODEBUG=") {
++		debug, found := strings.CutPrefix(env, "GODEBUG=")
++		if found {
++			opts := strings.Split(debug, ",")
++			for _, opt := range opts {
++				if strings.HasPrefix(opt, "fips140=") {
++					cmd.Env = append(cmd.Env, "GODEBUG="+opt)
++				}
++			}
+ 			continue
+ 		}
+ 		// Exclude GOTRACEBACK for the same reason.

--- a/scripts/crypto-test.sh
+++ b/scripts/crypto-test.sh
@@ -90,13 +90,13 @@ run_http_test_suite() {
   quiet pushd ${GOROOT}/src/net/http
   GOLANG_FIPS=1 OPENSSL_FORCE_FIPS_MODE=1 \
     $GO test $tags -count=1 $VERBOSE
+  quiet popd
 
   local suite="net-http-fips-parity-nocgo"
   notify_running ${mode} ${suite}
   quiet pushd ${GOROOT}/src/net/http
   GOLANG_FIPS=1 OPENSSL_FORCE_FIPS_MODE=1 \
     CGO_ENABLED=0 $GO test $tags -count=1 $VERBOSE
-
   quiet popd
 }
 
@@ -139,6 +139,7 @@ run_native_fips_test_suite() {
   # Must use GOFLAGS=-tags=no_openssl to disable OpenSSL backend in all subprocess calls
   GODEBUG=fips140=auto GOLANG_NATIVE_HOSTFIPS_OVERRIDE=1 GOFLAGS="-tags=no_openssl" \
     $GO test -tags=no_openssl -count=1 $($GO list -tags=no_openssl ./... | grep -v tls) $VERBOSE
+  quiet popd
 
   local suite="tls-native-fips"
   notify_running ${mode} ${suite}
@@ -146,7 +147,29 @@ run_native_fips_test_suite() {
   GODEBUG=fips140=auto GOLANG_NATIVE_HOSTFIPS_OVERRIDE=1 GOFLAGS="-tags=no_openssl" \
     $GO test -tags=no_openssl -count=1 crypto/tls -run "^TestBoring" $VERBOSE
   quiet popd
+}
 
+run_native_fips_strict_test_suite() {
+  local mode=$1
+  quiet pushd ${GOROOT}/src
+  notify_running ${mode} "native-fips-strict-auto"
+  local output=$(GOLANG_NATIVE_HOSTFIPS_OVERRIDE=1 GOEXPERIMENT=strictfipsruntime GODEBUG=fips140=auto $GO test -tags no_openssl crypto/sha256 -count=1 2>&1 || true)
+  if echo "$output" | grep -q "^ok"; then
+    echo "PASS: Native FIPS works when in strict fips mode"
+  else
+    echo "FAIL: Expected native FIPS to work without OpenSSL backend"
+    echo "Output: $output"
+    exit 1
+  fi
+  notify_running ${mode} "native-fips-strict-off"
+  local output=$(GOLANG_NATIVE_HOSTFIPS_OVERRIDE=1 GOEXPERIMENT=strictfipsruntime $GO test -tags no_openssl crypto/sha256 -count=1 2>&1 || true)
+  if echo "$output" | grep -q "Host FIPS mode is enabled, but the required GODEBUG=fips140 module is disabled"; then
+    echo "PASS: Native FIPS correctly aborts in strict fipsmode"
+  else
+    echo "Host FIPS mode is enabled, but the required GODEBUG=fips140 module is disabled"
+    echo "Output: $output"
+    exit 1
+  fi
   quiet popd
 }
 
@@ -234,6 +257,10 @@ fi
 
 if [[ "$MODES" == "all" || "$MODES" == *"native-fips-auto"* ]]; then
   run_native_fips_test_suite "native-fips-auto"
+fi
+
+if [[ "$MODES" == "all" || "$MODES" == *"native-fips-strict"* ]]; then
+  run_native_fips_strict_test_suite "native-fips-strict"
 fi
 
 if [[ "$MODES" == "all" || "$MODES" == *"mutual-exclusivity"* ]]; then


### PR DESCRIPTION
Previously, our strictfipsruntime mode still rejected binaries built with -tags no_openssl when the host is in FIPS mode.  This commit adds strictfipsruntime support for binaries built with -tags no_openssl or CGO_ENABLED=0.  With this change, when the host is in FIPS mode, components built with strictfipsruntime and without openssl will allow operation in native fips140 mode.

This commit also propagates GODEBUG=fips140 through the internal/testenv clean environment, to ensure that subprocesses inherit the parent's fips mode configuration. Otherwise, binaries built with strictfipsruntime and executed in the clean environment would crash as a result of strictfipsruntime enforcement.

Lastly, the commit includes minor fixes to crypto_test.sh where the working directory was not restored after running some tests.  This issue actually never manifested itself, because we always set the test directory in relation to GOROOT.